### PR TITLE
absorb {crypto,peer} test utils.

### DIFF
--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -7,7 +7,7 @@ import (
 
 	. "github.com/libp2p/go-libp2p-core/crypto"
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
-	"github.com/libp2p/go-libp2p-testing/crypto"
+	"github.com/libp2p/go-libp2p-core/test"
 )
 
 func TestKeys(t *testing.T) {
@@ -17,7 +17,7 @@ func TestKeys(t *testing.T) {
 }
 
 func testKeyType(typ int, t *testing.T) {
-	sk, pk, err := tcrypto.RandTestKeyPair(typ, 512)
+	sk, pk, err := test.RandTestKeyPair(typ, 512)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func testKeyEquals(t *testing.T, k Key) {
 		t.Fatal("Key not equal to key with same bytes.")
 	}
 
-	sk, pk, err := tcrypto.RandTestKeyPair(RSA, 512)
+	sk, pk, err := test.RandTestKeyPair(RSA, 512)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ipfs/go-cid v0.0.1
 	github.com/jbenet/goprocess v0.0.0-20160826012719-b497e2f366b8
 	github.com/libp2p/go-flow-metrics v0.0.1
-	github.com/libp2p/go-libp2p-testing v0.0.0-20190508172549-1a0da3de1915
 	github.com/minio/sha256-simd v0.0.0-20190131020904-2d45a736cd16
 	github.com/mr-tron/base58 v1.1.1
 	github.com/multiformats/go-multiaddr v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -32,9 +32,6 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/libp2p/go-flow-metrics v0.0.1 h1:0gxuFd2GuK7IIP5pKljLwps6TvcuYgvG7Atqi3INF5s=
 github.com/libp2p/go-flow-metrics v0.0.1/go.mod h1:Iv1GH0sG8DtYN3SVJ2eG221wMiNpZxBdp967ls1g+k8=
-github.com/libp2p/go-libp2p-core v0.0.0-20190508144953-ed42958fbb3a/go.mod h1:U1aaQsPt97g1BVcfdLEnzHdSNbaSg3Gh5eKgJ/KunKg=
-github.com/libp2p/go-libp2p-testing v0.0.0-20190508172549-1a0da3de1915 h1:ut3tAnP5cOMPZbUHEEhKnvJaJGorIUOdqz+UBC45T/g=
-github.com/libp2p/go-libp2p-testing v0.0.0-20190508172549-1a0da3de1915/go.mod h1:1FFj6xmoClrgHPBxgUgSSYWYxJ6CdkoP+s+sFf8nVgo=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 h1:lYpkrQH5ajf0OXOcUbGjvZxxijuBwbbmlSxLiuofa+g=
 github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1/go.mod h1:pD8RvIylQ358TN4wwqatJ8rNavkEINozVn9DtGI3dfQ=
 github.com/minio/sha256-simd v0.0.0-20190131020904-2d45a736cd16 h1:5W7KhL8HVF3XCFOweFD3BNESdnO8ewyYTFT2R+/b8FQ=

--- a/peer/peer_serde_test.go
+++ b/peer/peer_serde_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/libp2p/go-libp2p-core/peer"
-	. "github.com/libp2p/go-libp2p-testing/peer"
+	. "github.com/libp2p/go-libp2p-core/test"
 )
 
 func TestPeerSerdePB(t *testing.T) {

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
-	"github.com/libp2p/go-libp2p-testing/crypto"
+	"github.com/libp2p/go-libp2p-core/test"
 
 	. "github.com/libp2p/go-libp2p-core/peer"
-	"github.com/libp2p/go-libp2p-testing/peer"
+	"github.com/libp2p/go-libp2p-core/test"
 
 	b58 "github.com/mr-tron/base58/base58"
 	mh "github.com/multiformats/go-multihash"
@@ -49,7 +49,7 @@ type keyset struct {
 
 func (ks *keyset) generate() error {
 	var err error
-	ks.sk, ks.pk, err = tcrypto.RandTestKeyPair(ic.RSA, 512)
+	ks.sk, ks.pk, err = test.RandTestKeyPair(ic.RSA, 512)
 	if err != nil {
 		return err
 	}
@@ -217,7 +217,7 @@ func TestValidate(t *testing.T) {
 	}
 
 	// Non-empty peer ID validates
-	p, err := tpeer.RandPeerID()
+	p, err := test.RandPeerID()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/crypto.go
+++ b/test/crypto.go
@@ -1,0 +1,25 @@
+package test
+
+import (
+	"math/rand"
+	"sync/atomic"
+	"time"
+
+	ci "github.com/libp2p/go-libp2p-core/crypto"
+)
+
+var generatedPairs int64 = 0
+
+func RandTestKeyPair(typ, bits int) (ci.PrivKey, ci.PubKey, error) {
+	seed := time.Now().UnixNano()
+
+	// workaround for low time resolution
+	seed += atomic.AddInt64(&generatedPairs, 1) << 32
+
+	return SeededTestKeyPair(typ, bits, time.Now().UnixNano())
+}
+
+func SeededTestKeyPair(typ, bits int, seed int64) (ci.PrivKey, ci.PubKey, error) {
+	r := rand.New(rand.NewSource(seed))
+	return ci.GenerateKeyPairWithReader(typ, bits, r)
+}

--- a/test/peer.go
+++ b/test/peer.go
@@ -1,0 +1,30 @@
+package test
+
+import (
+	"io"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	mh "github.com/multiformats/go-multihash"
+)
+
+func RandPeerID() (peer.ID, error) {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	buf := make([]byte, 16)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return "", err
+	}
+	h, _ := mh.Sum(buf, mh.SHA2_256, -1)
+	return peer.ID(h), nil
+}
+
+func RandPeerIDFatal(t testing.TB) peer.ID {
+	p, err := RandPeerID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
+}


### PR DESCRIPTION
Avoids circular module dependency.