### PR TITLE
chore: cleanup address parsing

### DIFF
--- a/peer/addrinfo.go
+++ b/peer/addrinfo.go
@@ -47,6 +47,9 @@ func AddrInfoToP2pAddrs(pi *AddrInfo) ([]ma.Multiaddr, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(pi.Addrs) == 0 {
+		return []ma.Multiaddr{p2ppart}, nil
+	}
 	for _, addr := range pi.Addrs {
 		addrs = append(addrs, addr.Encapsulate(p2ppart))
 	}


### PR DESCRIPTION
* Use SplitLast to avoid allocating too much.
* Avoid converting to/from strings when working with multiaddrs.