### PR TITLE
peerstore/protobook: support removing protocols.

### DIFF
--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -158,5 +158,6 @@ type ProtoBook interface {
 	GetProtocols(peer.ID) ([]string, error)
 	AddProtocols(peer.ID, ...string) error
 	SetProtocols(peer.ID, ...string) error
+	RemoveProtocols(peer.ID, ...string) error
 	SupportsProtocols(peer.ID, ...string) ([]string, error)
 }


### PR DESCRIPTION
Necessary to apply protocol deltas from identify push (#17).