### PR TITLE
avoid marshaling the protobuf on compare

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -345,7 +345,19 @@ func KeyEqual(k1, k2 Key) bool {
 		return true
 	}
 
-	b1, err1 := k1.Bytes()
-	b2, err2 := k2.Bytes()
-	return bytes.Equal(b1, b2) && err1 == err2
+	if k1.Type() != k2.Type() {
+		return false
+	}
+
+	b1, err := k1.Raw()
+	if err != nil {
+		return false
+	}
+
+	b2, err := k2.Raw()
+	if err != nil {
+		return false
+	}
+
+	return bytes.Equal(b1, b2)
 }


### PR DESCRIPTION
We also should consider keeping these keys in their serialized form.