### PR TITLE
Feat/rsa caching

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -282,7 +282,20 @@ func UnmarshalPublicKey(data []byte) (PubKey, error) {
 		return nil, ErrBadKeyType
 	}
 
-	return um(pmes.GetData())
+	pk, err := um(pmes.GetData())
+	if err != nil {
+		return nil, err
+	}
+
+	switch tpk := pk.(type) {
+	case *RsaPublicKey:
+		bcopy := make([]byte, len(data))
+		copy(bcopy, data)
+
+		tpk.cached = bcopy
+	}
+
+	return pk, nil
 }
 
 // MarshalPublicKey converts a public key object into a protobuf serialized

--- a/crypto/openssl_common.go
+++ b/crypto/openssl_common.go
@@ -3,6 +3,8 @@
 package crypto
 
 import (
+	"sync"
+
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 
 	openssl "github.com/spacemonkeygo/openssl"
@@ -13,6 +15,9 @@ import (
 
 type opensslPublicKey struct {
 	key openssl.PublicKey
+
+	cacheLk sync.Mutex
+	cached  []byte
 }
 
 type opensslPrivateKey struct {
@@ -32,7 +37,7 @@ func unmarshalOpensslPublicKey(b []byte) (opensslPublicKey, error) {
 	if err != nil {
 		return opensslPublicKey{}, err
 	}
-	return opensslPublicKey{sk}, nil
+	return opensslPublicKey{key: sk, cached: b}, nil
 }
 
 // Verify compares a signature against input data
@@ -52,7 +57,13 @@ func (pk *opensslPublicKey) Type() pb.KeyType {
 
 // Bytes returns protobuf bytes of a public key
 func (pk *opensslPublicKey) Bytes() ([]byte, error) {
-	return MarshalPublicKey(pk)
+	pk.cacheLk.Lock()
+	var err error
+	if pk.cached == nil {
+		pk.cached, err = MarshalPublicKey(pk)
+	}
+	pk.cacheLk.Unlock()
+	return pk.cached, err
 }
 
 func (pk *opensslPublicKey) Raw() ([]byte, error) {
@@ -71,7 +82,7 @@ func (sk *opensslPrivateKey) Sign(message []byte) ([]byte, error) {
 
 // GetPublic returns a public key
 func (sk *opensslPrivateKey) GetPublic() PubKey {
-	return &opensslPublicKey{sk.key}
+	return &opensslPublicKey{key: sk.key}
 }
 
 func (sk *opensslPrivateKey) Type() pb.KeyType {

--- a/crypto/rsa_go.go
+++ b/crypto/rsa_go.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"io"
+	"sync"
 
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 
@@ -23,6 +24,9 @@ type RsaPrivateKey struct {
 // RsaPublicKey is an rsa public key
 type RsaPublicKey struct {
 	k rsa.PublicKey
+
+	cacheLk sync.Mutex
+	cached  []byte
 }
 
 // GenerateRSAKeyPair generates a new rsa private and public key
@@ -35,7 +39,7 @@ func GenerateRSAKeyPair(bits int, src io.Reader) (PrivKey, PubKey, error) {
 		return nil, nil, err
 	}
 	pk := priv.PublicKey
-	return &RsaPrivateKey{sk: *priv}, &RsaPublicKey{pk}, nil
+	return &RsaPrivateKey{sk: *priv}, &RsaPublicKey{k: pk}, nil
 }
 
 // Verify compares a signature against input data
@@ -54,7 +58,13 @@ func (pk *RsaPublicKey) Type() pb.KeyType {
 
 // Bytes returns protobuf bytes of a public key
 func (pk *RsaPublicKey) Bytes() ([]byte, error) {
-	return MarshalPublicKey(pk)
+	pk.cacheLk.Lock()
+	var err error
+	if pk.cached == nil {
+		pk.cached, err = MarshalPublicKey(pk)
+	}
+	pk.cacheLk.Unlock()
+	return pk.cached, err
 }
 
 func (pk *RsaPublicKey) Raw() ([]byte, error) {
@@ -74,7 +84,7 @@ func (sk *RsaPrivateKey) Sign(message []byte) ([]byte, error) {
 
 // GetPublic returns a public key
 func (sk *RsaPrivateKey) GetPublic() PubKey {
-	return &RsaPublicKey{sk.sk.PublicKey}
+	return &RsaPublicKey{k: sk.sk.PublicKey}
 }
 
 func (sk *RsaPrivateKey) Type() pb.KeyType {
@@ -121,5 +131,6 @@ func UnmarshalRsaPublicKey(b []byte) (PubKey, error) {
 	if pk.N.BitLen() < 512 {
 		return nil, ErrRsaKeyTooSmall
 	}
-	return &RsaPublicKey{*pk}, nil
+
+	return &RsaPublicKey{k: *pk}, nil
 }

--- a/crypto/rsa_openssl.go
+++ b/crypto/rsa_openssl.go
@@ -29,12 +29,12 @@ func GenerateRSAKeyPair(bits int, _ io.Reader) (PrivKey, PubKey, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	return &RsaPrivateKey{opensslPrivateKey{key}}, &RsaPublicKey{opensslPublicKey{key}}, nil
+	return &RsaPrivateKey{opensslPrivateKey{key}}, &RsaPublicKey{opensslPublicKey{key: key}}, nil
 }
 
 // GetPublic returns a public key
 func (sk *RsaPrivateKey) GetPublic() PubKey {
-	return &RsaPublicKey{opensslPublicKey{sk.opensslPrivateKey.key}}
+	return &RsaPublicKey{opensslPublicKey{key: sk.opensslPrivateKey.key}}
 }
 
 // UnmarshalRsaPrivateKey returns a private key from the input x509 bytes

--- a/crypto/rsa_test.go
+++ b/crypto/rsa_test.go
@@ -2,6 +2,7 @@ package crypto
 
 import (
 	"crypto/rand"
+	mrand "math/rand"
 	"testing"
 )
 
@@ -98,5 +99,17 @@ func TestRSAMarshalLoop(t *testing.T) {
 
 	if !pub.Equals(pubNew) || !pubNew.Equals(pub) {
 		t.Fatal("keys are not equal")
+	}
+}
+
+func BenchmarkRSAKeyEqualsCheck(b *testing.B) {
+	r := mrand.New(mrand.NewSource(42))
+	_, k1, _ := GenerateRSAKeyPair(2048, r)
+	_, k2, _ := GenerateRSAKeyPair(2048, r)
+
+	for i := 0; i < b.N; i++ {
+		if k1.Equals(k2) {
+			b.Fatal("this bad")
+		}
 	}
 }


### PR DESCRIPTION
This is making GC realllly hot on the machines i've been watching.

Here's the before and after benchmark results:

Before:
```
why@WhyNet ~/g/s/g/l/g/crypto> go test -run XXXX -bench=BenchmarkRSAKey
goos: darwin
goarch: amd64
pkg: github.com/libp2p/go-libp2p-core/crypto
BenchmarkRSAKeyEqualsCheck-4   	  100000	     13415 ns/op	    5443 B/op	     118 allocs/op
PASS
ok  	github.com/libp2p/go-libp2p-core/crypto	4.706s

why@WhyNet ~/g/s/g/l/g/crypto> go test -run XXXX -bench=BenchmarkRSAKey -tags=openssl
# github.com/libp2p/go-libp2p-core/crypto.test
ld: warning: directory not found for option '-L/usr/local/opt/openssl@1.1/lib'
goos: darwin
goarch: amd64
pkg: github.com/libp2p/go-libp2p-core/crypto
BenchmarkRSAKeyEqualsCheck-4   	  100000	     14560 ns/op	    5024 B/op	      18 allocs/op
PASS
ok  	github.com/libp2p/go-libp2p-core/crypto	2.789s
```

After:

```
why@WhyNet ~/g/s/g/l/g/crypto> go test -run XXXX -bench=BenchmarkRSAKey
goos: darwin
goarch: amd64
pkg: github.com/libp2p/go-libp2p-core/crypto
BenchmarkRSAKeyEqualsCheck-4   	20000000	        69.6 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/libp2p/go-libp2p-core/crypto	6.666s

why@WhyNet ~/g/s/g/l/g/crypto> go test -run XXXX -bench=BenchmarkRSAKey -tags=openssl
# github.com/libp2p/go-libp2p-core/crypto.test
ld: warning: directory not found for option '-L/usr/local/opt/openssl@1.1/lib'
goos: darwin
goarch: amd64
pkg: github.com/libp2p/go-libp2p-core/crypto
BenchmarkRSAKeyEqualsCheck-4   	30000000	        52.5 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/libp2p/go-libp2p-core/crypto	3.788s
```