### PR TITLE
Use standard library "crypto/ed25519"

### DIFF
--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -2,13 +2,12 @@ package crypto
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"errors"
 	"fmt"
 	"io"
 
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 // Ed25519PrivateKey is an ed25519 private key.

--- a/crypto/ed25519_test.go
+++ b/crypto/ed25519_test.go
@@ -1,12 +1,11 @@
 package crypto
 
 import (
+	"crypto/ed25519"
 	"crypto/rand"
 	"testing"
 
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
-
-	"golang.org/x/crypto/ed25519"
 )
 
 func TestBasicSignAndVerify(t *testing.T) {


### PR DESCRIPTION
It requires Go1.13

Related: https://github.com/libp2p/go-libp2p-quic-transport/pull/65