### PR TITLE
Replace bytes.Equal -> subtle.ConstantTimeCompare

### DIFF
--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -115,7 +115,7 @@ func (ePriv *ECDSAPrivateKey) Raw() ([]byte, error) {
 	return x509.MarshalECPrivateKey(ePriv.priv)
 }
 
-// Equals compares to private keys
+// Equals compares two private keys
 func (ePriv *ECDSAPrivateKey) Equals(o Key) bool {
 	oPriv, ok := o.(*ECDSAPrivateKey)
 	if !ok {

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -1,7 +1,7 @@
 package crypto
 
 import (
-	"bytes"
+	"crypto/subtle"
 	"errors"
 	"fmt"
 	"io"
@@ -70,7 +70,7 @@ func (k *Ed25519PrivateKey) Equals(o Key) bool {
 		return false
 	}
 
-	return bytes.Equal(k.k, edk.k)
+	return subtle.ConstantTimeCompare(k.k, edk.k) == 1
 }
 
 // GetPublic returns an ed25519 public key from a private key.
@@ -105,7 +105,7 @@ func (k *Ed25519PublicKey) Equals(o Key) bool {
 		return false
 	}
 
-	return bytes.Equal(k.k, edk.k)
+	return subtle.ConstantTimeCompare(k.k, edk.k) == 1
 }
 
 // Verify checks a signature agains the input data.
@@ -131,7 +131,7 @@ func UnmarshalEd25519PrivateKey(data []byte) (PrivKey, error) {
 		// Remove the redundant public key. See issue #36.
 		redundantPk := data[ed25519.PrivateKeySize:]
 		pk := data[ed25519.PrivateKeySize-ed25519.PublicKeySize : ed25519.PrivateKeySize]
-		if !bytes.Equal(pk, redundantPk) {
+		if subtle.ConstantTimeCompare(pk, redundantPk) != 1 {
 			return nil, errors.New("expected redundant ed25519 public key to be redundant")
 		}
 

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"bytes"
 	"crypto/subtle"
 	"errors"
 	"fmt"
@@ -105,7 +106,7 @@ func (k *Ed25519PublicKey) Equals(o Key) bool {
 		return false
 	}
 
-	return subtle.ConstantTimeCompare(k.k, edk.k) == 1
+	return bytes.Equal(k.k, edk.k)
 }
 
 // Verify checks a signature agains the input data.
@@ -131,7 +132,7 @@ func UnmarshalEd25519PrivateKey(data []byte) (PrivKey, error) {
 		// Remove the redundant public key. See issue #36.
 		redundantPk := data[ed25519.PrivateKeySize:]
 		pk := data[ed25519.PrivateKeySize-ed25519.PublicKeySize : ed25519.PrivateKeySize]
-		if subtle.ConstantTimeCompare(pk, redundantPk) != 1 {
+		if !bytes.Equal(pk, redundantPk) {
 			return nil, errors.New("expected redundant ed25519 public key to be redundant")
 		}
 

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -4,12 +4,12 @@
 package crypto
 
 import (
-	"bytes"
 	"crypto/elliptic"
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha1"
 	"crypto/sha512"
+	"crypto/subtle"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -347,5 +347,5 @@ func KeyEqual(k1, k2 Key) bool {
 
 	b1, err1 := k1.Bytes()
 	b2, err2 := k2.Bytes()
-	return bytes.Equal(b1, b2) && err1 == err2
+	return subtle.ConstantTimeCompare(b1, b2) == 1 && err1 == err2
 }


### PR DESCRIPTION
Removes reliance on short-circuiting equality comparisons which can be cryptographically unsound.