### PR TITLE
Return error rather than panic in GenerateEKeyPair

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -143,6 +143,8 @@ func GenerateEKeyPair(curveName string) ([]byte, GenSharedKey, error) {
 		curve = elliptic.P384()
 	case "P-521":
 		curve = elliptic.P521()
+	default:
+		return nil, nil, fmt.Errorf("unknown curve name")
 	}
 
 	priv, x, y, err := elliptic.GenerateKey(curve, rand.Reader)

--- a/crypto/key_test.go
+++ b/crypto/key_test.go
@@ -145,3 +145,15 @@ func (pk testkey) Raw() ([]byte, error) {
 func (pk testkey) Equals(k Key) bool {
 	return KeyEqual(pk, k)
 }
+
+func TestUnknownCurveErrors(t *testing.T) {
+	_, _, err := GenerateEKeyPair("P-256")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = GenerateEKeyPair("error-please")
+	if err == nil {
+		t.Fatal("expected invalid key type to error")
+	}
+}


### PR DESCRIPTION
Stops us from panicking in the event that we receive a curve we don't support.