### PR TITLE
avoid duplicate randomly generated keys/peer-ids

### DIFF
--- a/test/crypto.go
+++ b/test/crypto.go
@@ -3,20 +3,16 @@ package test
 import (
 	"math/rand"
 	"sync/atomic"
-	"time"
 
 	ci "github.com/libp2p/go-libp2p-core/crypto"
 )
 
-var generatedPairs int64 = 0
+var globalSeed int64
 
 func RandTestKeyPair(typ, bits int) (ci.PrivKey, ci.PubKey, error) {
-	seed := time.Now().UnixNano()
-
 	// workaround for low time resolution
-	seed += atomic.AddInt64(&generatedPairs, 1) << 32
-
-	return SeededTestKeyPair(typ, bits, time.Now().UnixNano())
+	seed := atomic.AddInt64(&globalSeed, 1)
+	return SeededTestKeyPair(typ, bits, seed)
 }
 
 func SeededTestKeyPair(typ, bits int, seed int64) (ci.PrivKey, ci.PubKey, error) {

--- a/test/peer.go
+++ b/test/peer.go
@@ -1,10 +1,8 @@
 package test
 
 import (
-	"io"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 
@@ -12,11 +10,8 @@ import (
 )
 
 func RandPeerID() (peer.ID, error) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	buf := make([]byte, 16)
-	if _, err := io.ReadFull(r, buf); err != nil {
-		return "", err
-	}
+	rand.Read(buf)
 	h, _ := mh.Sum(buf, mh.SHA2_256, -1)
 	return peer.ID(h), nil
 }


### PR DESCRIPTION
This implements #4 from #43.

fixes #43