### PR TITLE
fix: Store marshalled protobuf in cache for RsaPublicKey.Bytes()

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -299,10 +299,7 @@ func PublicKeyFromProto(pmes *pb.PublicKey) (PubKey, error) {
 
 	switch tpk := pk.(type) {
 	case *RsaPublicKey:
-		bcopy := make([]byte, len(data))
-		copy(bcopy, data)
-
-		tpk.cached = bcopy
+		tpk.cached, _ = pmes.Marshal()
 	}
 
 	return pk, nil


### PR DESCRIPTION
We were storing the key data in the cache instead of the key wrapped in the protobuf. This is inconsistent with how we return the data in the `Bytes()` function and was causing the `TestFixtures` test to fail.