### PR TITLE
fix: get `remoteID` from pb message in plaintext

### DIFF
--- a/sec/insecure/insecure.go
+++ b/sec/insecure/insecure.go
@@ -162,7 +162,7 @@ func (ic *Conn) runHandshakeSync() error {
 		return err
 	}
 
-	remoteID, err := peer.IDFromPublicKey(remotePubkey)
+	remoteID, err := peer.IDFromBytes(remoteMsg.Id)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Instead of calculated from the public key. Otherwise,
```go
remoteID.MatchesPublicKey(remotePubkey)
```
is always `True`.