### PR TITLE
Fix documentation missmatch for crypto methods.

### DIFF
--- a/crypto/key.go
+++ b/crypto/key.go
@@ -349,12 +349,12 @@ func MarshalPrivateKey(k PrivKey) ([]byte, error) {
 	return proto.Marshal(pbmes)
 }
 
-// ConfigDecodeKey decodes from b64 (for config file), and unmarshals.
+// ConfigDecodeKey decodes from b64 (for config file) to a byte array that can be unmarshalled.
 func ConfigDecodeKey(b string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(b)
 }
 
-// ConfigEncodeKey encodes to b64 (for config file), and marshals.
+// ConfigEncodeKey encodes a marshalled key to b64 (for config file).
 func ConfigEncodeKey(b []byte) string {
 	return base64.StdEncoding.EncodeToString(b)
 }


### PR DESCRIPTION
The docs seem to lie about what the `ConfigEncodeKey` and `ConfigDecodeKey` methods do. Currently they seem to simply be wrappers around base 64 encoding and decoding.

The simple fix is to update the docs but is it possible to get these methods
to marshal to public or private key correctly by passing a "type" (reflect.Type or something) to them?

(First day using go, otherwise I would have taken an actual stab at this)