### PR TITLE
Remove Public Key

### DIFF
--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -130,6 +130,9 @@ type KeyBook interface {
 	// AddPubKey stores the public key of a peer.
 	AddPubKey(peer.ID, ic.PubKey) error
 
+	// RemovePubKey removes the public key of a peer.
+	RemovePubKey(peer.ID) error
+
 	// PrivKey returns the private key of a peer, if known. Generally this might only be our own
 	// private key, see
 	// https://discuss.libp2p.io/t/what-is-the-purpose-of-having-map-peer-id-privatekey-in-peerstore/74.


### PR DESCRIPTION
For https://github.com/libp2p/go-libp2p-peerstore/issues/93
Looks like only Remove Public Key is required.