### PR TITLE
chore(metrics): expose reset as part of the interface

### DIFF
--- a/metrics/bandwidth.go
+++ b/metrics/bandwidth.go
@@ -21,6 +21,8 @@ type BandwidthCounter struct {
 	peerOut flow.MeterRegistry
 }
 
+var _ Reporter = (*BandwidthCounter)(nil)
+
 // NewBandwidthCounter creates a new BandwidthCounter.
 func NewBandwidthCounter() *BandwidthCounter {
 	return new(BandwidthCounter)

--- a/metrics/reporter.go
+++ b/metrics/reporter.go
@@ -28,4 +28,7 @@ type Reporter interface {
 	GetBandwidthTotals() Stats
 	GetBandwidthByPeer() map[peer.ID]Stats
 	GetBandwidthByProtocol() map[protocol.ID]Stats
+
+	// Reset clears all state.
+	Reset()
 }


### PR DESCRIPTION
https://github.com/libp2p/go-libp2p-core/pull/71 added the function to the implementation but didn't change the interface.