### PR TITLE
use varints for delimiting plaintext 2.0 msgs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/ipfs/go-cid v0.0.3
 	github.com/jbenet/goprocess v0.1.3
 	github.com/libp2p/go-flow-metrics v0.0.2
-	github.com/libp2p/go-msgio v0.0.4
 	github.com/libp2p/go-openssl v0.0.3
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mr-tron/base58 v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -64,14 +64,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/libp2p/go-buffer-pool v0.0.1 h1:9Rrn/H46cXjaA2HQ5Y8lyhOS1NhTkZ4yuEs2r3Eechg=
-github.com/libp2p/go-buffer-pool v0.0.1/go.mod h1:xtyIz9PMobb13WaxR6Zo1Pd1zXJKYg0a8KiIvDp3TzQ=
 github.com/libp2p/go-flow-metrics v0.0.2 h1:U5TvqfoyR6GVRM+bC15Ux1ltar1kbj6Zw6xOVR02CZs=
 github.com/libp2p/go-flow-metrics v0.0.2/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
-github.com/libp2p/go-msgio v0.0.4 h1:agEFehY3zWJFUHK6SEMR7UYmk2z6kC3oeCM7ybLhguA=
-github.com/libp2p/go-msgio v0.0.4 h1:agEFehY3zWJFUHK6SEMR7UYmk2z6kC3oeCM7ybLhguA=
-github.com/libp2p/go-msgio v0.0.4/go.mod h1:63lBBgOTDKQL6EWazRMCwXsEeEeK9O2Cd+0+6OOuipQ=
-github.com/libp2p/go-msgio v0.0.4/go.mod h1:63lBBgOTDKQL6EWazRMCwXsEeEeK9O2Cd+0+6OOuipQ=
 github.com/libp2p/go-openssl v0.0.3 h1:wjlG7HvQkt4Fq4cfH33Ivpwp0omaElYEi9z26qaIkIk=
 github.com/libp2p/go-openssl v0.0.3/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=

--- a/sec/insecure/insecure.go
+++ b/sec/insecure/insecure.go
@@ -183,7 +183,7 @@ func (ic *Conn) runHandshakeSync() error {
 
 // read and write a message at the same time.
 func readWriteMsg(rw io.ReadWriter, out *pb.Exchange) (*pb.Exchange, error) {
-	const maxMsgSize = 1 << 32
+	const maxMsgSize = 1 << 16
 	r := gogoio.NewDelimitedReader(rw, maxMsgSize)
 	w := gogoio.NewDelimitedWriter(rw)
 	wresult := make(chan error)
@@ -194,7 +194,7 @@ func readWriteMsg(rw io.ReadWriter, out *pb.Exchange) (*pb.Exchange, error) {
 	inMsg := pb.Exchange{}
 	err := r.ReadMsg(&inMsg)
 
-	// Always wait for the read to finish.
+	// Always wait for the write to finish.
 	err2 := <-wresult
 
 	if err != nil {

--- a/sec/insecure/insecure.go
+++ b/sec/insecure/insecure.go
@@ -6,11 +6,13 @@ package insecure
 import (
 	"context"
 	"fmt"
+	"io"
 	"net"
+
+	gogoio "github.com/gogo/protobuf/io"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/sec"
-	"github.com/libp2p/go-msgio"
 
 	ci "github.com/libp2p/go-libp2p-core/crypto"
 	pb "github.com/libp2p/go-libp2p-core/sec/insecure/pb"
@@ -143,7 +145,6 @@ func (ic *Conn) runHandshakeSync() error {
 		return nil
 	}
 
-	rw := msgio.NewReadWriter(ic.Conn)
 	// Generate an Exchange message
 	msg, err := makeExchangeMessage(ic.localPrivKey.GetPublic())
 	if err != nil {
@@ -151,7 +152,7 @@ func (ic *Conn) runHandshakeSync() error {
 	}
 
 	// Send our Exchange and read theirs
-	remoteMsg, err := readWriteMsg(rw, msg)
+	remoteMsg, err := readWriteMsg(ic.Conn, msg)
 	if err != nil {
 		return err
 	}
@@ -181,31 +182,28 @@ func (ic *Conn) runHandshakeSync() error {
 }
 
 // read and write a message at the same time.
-func readWriteMsg(c msgio.ReadWriter, out *pb.Exchange) (*pb.Exchange, error) {
-	outBytes, err := out.Marshal()
-	if err != nil {
-		return nil, err
-	}
+func readWriteMsg(rw io.ReadWriter, out *pb.Exchange) (*pb.Exchange, error) {
+	const maxMsgSize = 1 << 32
+	r := gogoio.NewDelimitedReader(rw, maxMsgSize)
+	w := gogoio.NewDelimitedWriter(rw)
 	wresult := make(chan error)
 	go func() {
-		wresult <- c.WriteMsg(outBytes)
+		wresult <- w.WriteMsg(out)
 	}()
 
-	msg, err1 := c.ReadMsg()
+	inMsg := pb.Exchange{}
+	err := r.ReadMsg(&inMsg)
 
 	// Always wait for the read to finish.
 	err2 := <-wresult
 
-	if err1 != nil {
-		return nil, err1
+	if err != nil {
+		return nil, err
 	}
 	if err2 != nil {
-		c.ReleaseMsg(msg)
 		return nil, err2
 	}
-	inMsg := new(pb.Exchange)
-	err = inMsg.Unmarshal(msg)
-	return inMsg, err
+	return &inMsg, err
 }
 
 // LocalPeer returns the local peer ID.


### PR DESCRIPTION
This fixes a bug in plaintext 2.0, which according to the spec should use varints for delimiting messages. I used `go-msgio` thinking that it used varints under the hood, but it actually uses 4 byte unsigned ints instead.

This switches out msgio for gogoprotobuf's varint delimited Reader / Writer types.