### PR TITLE
feat(metrics): add function to trim idle meters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/ipfs/go-cid v0.0.3
 	github.com/jbenet/goprocess v0.1.3
-	github.com/libp2p/go-flow-metrics v0.0.2
+	github.com/libp2p/go-flow-metrics v0.0.3
 	github.com/libp2p/go-openssl v0.0.3
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mr-tron/base58 v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/libp2p/go-flow-metrics v0.0.2 h1:U5TvqfoyR6GVRM+bC15Ux1ltar1kbj6Zw6xOVR02CZs=
-github.com/libp2p/go-flow-metrics v0.0.2/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
+github.com/libp2p/go-flow-metrics v0.0.3 h1:8tAs/hSdNvUiLgtlSy3mxwxWP4I9y/jlkPFT7epKdeM=
+github.com/libp2p/go-flow-metrics v0.0.3/go.mod h1:HeoSNUrOJVK1jEpDqVEiUOIXqhbnS27omG0uWU5slZs=
 github.com/libp2p/go-openssl v0.0.3 h1:wjlG7HvQkt4Fq4cfH33Ivpwp0omaElYEi9z26qaIkIk=
 github.com/libp2p/go-openssl v0.0.3/go.mod h1:unDrJpgy3oFr+rqXsarWifmJuNnJR4chtO1HmaZjggc=
 github.com/mailru/easyjson v0.0.0-20180823135443-60711f1a8329 h1:2gxZ0XQIU/5z3Z3bUBu+FXuk2pFbkN6tcwi/pjyaDic=

--- a/metrics/bandwidth.go
+++ b/metrics/bandwidth.go
@@ -2,6 +2,8 @@
 package metrics
 
 import (
+	"time"
+
 	"github.com/libp2p/go-flow-metrics"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
@@ -162,4 +164,12 @@ func (bwc *BandwidthCounter) Reset() {
 
 	bwc.peerIn.Clear()
 	bwc.peerOut.Clear()
+}
+
+// TrimIdle trims all timers idle since the given time.
+func (bwc *BandwidthCounter) TrimIdle(since time.Time) {
+	bwc.peerIn.TrimIdle(since)
+	bwc.peerOut.TrimIdle(since)
+	bwc.protocolIn.TrimIdle(since)
+	bwc.protocolOut.TrimIdle(since)
 }


### PR DESCRIPTION
We could, alternatively, provide a "GC period" along with a Close method.
However, letting the application choose when to trim idle timers seems like a
more flexible option.