### PR TITLE
Update peer

### DIFF
--- a/peer/addrinfo.go
+++ b/peer/addrinfo.go
@@ -29,11 +29,7 @@ func AddrInfosFromP2pAddrs(maddrs ...ma.Multiaddr) ([]AddrInfo, error) {
 		if id == "" {
 			return nil, ErrInvalidAddr
 		}
-		if transport == nil {
-			if _, ok := m[id]; !ok {
-				m[id] = nil
-			}
-		} else {
+		if transport != nil {
 			m[id] = append(m[id], transport)
 		}
 	}

--- a/peer/addrinfo_test.go
+++ b/peer/addrinfo_test.go
@@ -87,7 +87,7 @@ func TestAddrInfosFromP2pAddrs(t *testing.T) {
 	if len(infos) != 0 {
 		t.Fatal("expected no addrs")
 	}
-	infos, err = AddrInfosFromP2pAddrs(nil)
+	_, err = AddrInfosFromP2pAddrs(nil)
 	if err == nil {
 		t.Fatal("expected nil multiaddr to fail")
 	}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -226,7 +226,7 @@ func IDFromPublicKey(pk ic.PubKey) (ID, error) {
 	}
 	var alg uint64 = mh.SHA2_256
 	if AdvancedEnableInlining && len(b) <= maxInlineKeyLength {
-		alg = mh.ID
+		alg = mh.IDENTITY
 	}
 	hash, _ := mh.Sum(b, alg, -1)
 	return ID(hash), nil

--- a/peer/set.go
+++ b/peer/set.go
@@ -63,7 +63,7 @@ func (ps *Set) TryAdd(p ID) bool {
 func (ps *Set) Peers() []ID {
 	ps.lk.Lock()
 	out := make([]ID, 0, len(ps.ps))
-	for p, _ := range ps.ps {
+	for p := range ps.ps {
 		out = append(out, p)
 	}
 	ps.lk.Unlock()


### PR DESCRIPTION
1. fix some staticcheck
2. Drop map default value in AddrInfosFromP2pAddrs
    Go's default behavior is to return the "zero value" for the key not existed in map. there's no need to explicit to do this.
