### PR TITLE
sketch interface for connection gating.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.11.x
+  - 1.13.x
 
 env:
   global:

--- a/connmgr/connmgr.go
+++ b/connmgr/connmgr.go
@@ -65,6 +65,30 @@ type ConnManager interface {
 	Close() error
 }
 
+// ConnectionGater can be implemented by connection managers that support active
+// inbound or outbound connection gating.
+//
+// By default, connection managers are assumed to act like passive sentinels.
+// They sit in the background, watching connections that are established and
+// tracking their score. They perform batch pruning every once in a while to
+// bring the system into equilibrium.
+//
+// A ConnManager implementing ConnectionGater can be consulted by the
+// network.Network (a) before initiating a connection attempt for outbound
+// connections, or (b) incorporating an inbound connection into the node's
+// state. The bool return value indicates whether the caller should proceed.
+//
+// This feature can be used to implement *strict* connection management
+// behaviours, such as hard limiting of connections once a max count has been
+// reached.
+type ConnectionGater interface {
+	// AllowConnection tests whether the given connection is allowed to happen.
+	//
+	// The caller must supply the direction and the peer ID to be tested, and
+	// optionally a network.Conn if one has already been created.
+	AllowConnection(network.Direction, peer.ID, network.Conn) bool
+}
+
 // TagInfo stores metadata associated with a peer.
 type TagInfo struct {
 	FirstSeen time.Time


### PR DESCRIPTION
For https://github.com/libp2p/go-libp2p/issues/872.

Some downstreams (e.g. Prysmatic, @prestonvanloon, @nisdas) need to actively and strictly limit/deny outbound and inbound connection attempts, after a limit has been reached. On the other hand, other downstreams like Filecoin require peer blacklisting capability.

Enhancing go-libp2p-swarm with peer/connection limit or blacklisting functionality is a dirty solution. The right place to put this concern is in the connection management domain. But not all connection manager implementations will want to act as firewalls or blacklisters.

This PR sketches out a `ConnectionGater` interface that connmgr implementations can implement. The swarm tests if the interface is implemented, and if so, calls `AllowConnection()` before performing any dials (outgoing connection), or incorporating a candidate connection to the swarm (incoming connection). Ideally we'd stop incoming connections at the transport layer, but injecting the connmgr so deep is not something I'm comfortable with.

**TODO:**

- [ ] Gracefully disconnecting the other party -- DISCONNECT protocol: https://github.com/libp2p/go-libp2p/issues/238. If we don't implement this, the other party has no way of knowing if the disconnection was product of a network hiccup, or if it was intentional. And they may try to reconnect.
- [ ] Add the call sites in the swarm.

Before I finish up the remaining work, I'd love to gather some feedback.

Relates to https://github.com/libp2p/go-libp2p-swarm/pull/146.