### PR TITLE
Use `PeerRecord` value instead of pointer  in `EvtLocalPeerRecordUpdated`

### DIFF
--- a/event/addrs.go
+++ b/event/addrs.go
@@ -78,5 +78,5 @@ type EvtLocalAddressesUpdated struct {
 type EvtLocalPeerRecordUpdated struct {
 	// Record contains the updated peer.PeerRecord, wrapped in a record.Envelope and
 	// signed by the Host's private key.
-	Record *record.Envelope
+	Record record.Envelope
 }


### PR DESCRIPTION
Small update to #73 that changes the `EvtLocalPeerRecordUpdated` event struct so that it embeds a `PeerRecord` value, instead of a pointer to a `PeerRecord`. This prevents record from being modified by receivers.