### PR TITLE
chore(license): fix license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,4 @@
+Dual-licensed under MIT and ASLv2, by way of the [Permissive License Stack](https://protocol.ai/blog/announcing-the-permissive-license-stack/).
+
+Apache-2.0: https://www.apache.org/licenses/license-2.0
+MIT: https://www.opensource.org/licenses/mit


### PR DESCRIPTION
Adding URLs to the licenses will cause go to detect this project as Apache 2.0.

fix #114