### PR TITLE
WIP peerstore: model address provenance data type.

### DIFF
--- a/peerstore/provenance.go
+++ b/peerstore/provenance.go
@@ -1,0 +1,78 @@
+package peerstore
+
+import (
+	"fmt"
+	"sync"
+)
+
+// AddressProvenance specifies the provenance of an address that has been stored
+// in the peerstore.
+//
+// Values [0x00, 0x80) are RESERVED for the developers of libp2p.
+//
+// Users are free to register custom application-level provenances in the range
+// [0x80, 0xff], via the RegisterAddressProvenance function.
+type AddressProvenance uint8
+
+const (
+	// ProvenanceUnknown means that the provenance of an address is unknown.
+	//
+	// This is usually the case when an address has been inserted through the
+	// legacy methods of the peerstore.
+	ProvenanceUnknown = AddressProvenance(0x00)
+
+	// ProvenanceThirdParty indicates that we've learnt this address via a third
+	// party.
+	ProvenanceThirdParty = AddressProvenance(0x10)
+
+	// ProvenanceUntrusted means that an address has been returned by the peer
+	// in question, but it is not authenticated, i.e. it is not part of a peer
+	// record.
+	ProvenanceUntrusted = AddressProvenance(0x20)
+
+	// ProvenanceTrusted means that the address is part of an authenticated
+	// standard libp2p peer record.
+	ProvenanceTrusted = AddressProvenance(0x30)
+
+	// ProvenanceManual means that an address has been specified manually by a
+	// human, and therefore should take high precedence.
+	ProvenanceManual = AddressProvenance(0x7f)
+)
+
+var (
+	// provenanceLk only guards registration (i.e. writes, not reads).
+	//
+	// It is assumed that user-defined provenances will be registered during
+	// system initialisation. Once the system becomes operational, the
+	// descriptions are accessed by the String() method without taking a lock.
+	provenanceLk sync.Mutex
+
+	// provenanceDescs are the descriptions of the provenances, for debugging
+	// purposes.
+	provenanceDescs = [256]string{
+		0x00: "unknown",
+		0x10: "third_party",
+		0x20: "untrusted",
+		0x30: "trusted",
+		0x7f: "manual",
+	}
+)
+
+func (p AddressProvenance) String() string {
+	return provenanceDescs[p]
+}
+
+func RegisterAddressProvenance(p AddressProvenance, desc string) error {
+	provenanceLk.Lock()
+	defer provenanceLk.Unlock()
+
+	if p < 0x80 {
+		return fmt.Errorf("failed to register user-defined address provenance "+
+			"due to range violation; should be in [0x80,0xff]; was: %x", p)
+	}
+	if d := provenanceDescs[p]; d != "" {
+		return fmt.Errorf("an address provenance for code %x already exists: %s", p, d)
+	}
+	provenanceDescs[p] = desc
+	return nil
+}


### PR DESCRIPTION
This PR introduces an `AddressProvenance` data type that acts like an _unsealed_ enum. This means that users can add user-defined values, and have them tracked by the peerstore.

Address provenances are single-byte values. The range [0x00, 0x80) is reserved for libp2p, and we ship with five values (from lowest to highest precedence): unknown, third party, untrusted, trusted, manual.

The range [0x80, 0xff] is at the disposal of users.

---

The proposal to incorporate this feature in the peerstore APIs consists of adding: `...peerstore.ReadOption` and `...peerstore.WriteOption` arguments to peerstore methods, to record the provenance when inserting addresses, and filter by provenances when querying and filtering addresses.

That interface change, coupled with the `unknown` default value, would allow users to stay non-breaking. Implementations of the `AddrBook` interface would break; but AFAIK, we are the only implementers, so the shockwave is greatly absorbed.