### PR TITLE
docs: uniform comment sentences

### DIFF
--- a/connmgr/connmgr.go
+++ b/connmgr/connmgr.go
@@ -61,7 +61,7 @@ type ConnManager interface {
 	// See notes on Protect() for more info.
 	Unprotect(id peer.ID, tag string) (protected bool)
 
-	// Close closes the connection manager and stops background processes
+	// Close closes the connection manager and stops background processes.
 	Close() error
 }
 

--- a/peer/addrinfo.go
+++ b/peer/addrinfo.go
@@ -74,7 +74,7 @@ func AddrInfoFromP2pAddr(m ma.Multiaddr) (*AddrInfo, error) {
 	return info, nil
 }
 
-// AddrInfoToP2pAddr converts an AddrInfo to a list of Multiaddrs.
+// AddrInfoToP2pAddrs converts an AddrInfo to a list of Multiaddrs.
 func AddrInfoToP2pAddrs(pi *AddrInfo) ([]ma.Multiaddr, error) {
 	var addrs []ma.Multiaddr
 	p2ppart, err := ma.NewComponent("p2p", IDB58Encode(pi.ID))

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -57,7 +57,7 @@ func (id ID) String() string {
 	return id.Pretty()
 }
 
-// String prints out the peer ID.
+// ShortString prints out the peer ID.
 //
 // TODO(brian): ensure correctness at ID generation and
 // enforce this by only exposing functions that generate
@@ -85,7 +85,7 @@ func (id ID) MatchesPublicKey(pk ic.PubKey) bool {
 	return oid == id
 }
 
-// ExtractPublicKey attempts to extract the public key from an ID
+// ExtractPublicKey attempts to extract the public key from an ID.
 //
 // This method returns ErrNoPublicKey if the peer ID looks valid but it can't extract
 // the public key.
@@ -237,7 +237,7 @@ func IDFromPrivateKey(sk ic.PrivKey) (ID, error) {
 	return IDFromPublicKey(sk.GetPublic())
 }
 
-// IDSlice for sorting peers
+// IDSlice for sorting peers.
 type IDSlice []ID
 
 func (es IDSlice) Len() int           { return len(es) }

--- a/peer/peer_serde.go
+++ b/peer/peer_serde.go
@@ -1,4 +1,4 @@
-// This file contains Protobuf and JSON serialization/deserialization methods for peer IDs.
+// Package peer contains Protobuf and JSON serialization/deserialization methods for peer IDs.
 package peer
 
 import (
@@ -21,7 +21,7 @@ func (id ID) Marshal() ([]byte, error) {
 	return []byte(id), nil
 }
 
-// BinaryMarshal returns the byte representation of the peer ID.
+// MarshalBinary returns the byte representation of the peer ID.
 func (id ID) MarshalBinary() ([]byte, error) {
 	return id.Marshal()
 }
@@ -35,12 +35,12 @@ func (id *ID) Unmarshal(data []byte) (err error) {
 	return err
 }
 
-// BinaryUnmarshal sets the ID from its binary representation.
+// UnmarshalBinary sets the ID from its binary representation.
 func (id *ID) UnmarshalBinary(data []byte) error {
 	return id.Unmarshal(data)
 }
 
-// Implements Gogo's proto.Sizer, but we omit the compile-time assertion to avoid introducing a hard
+// Size implements Gogo's proto.Sizer, but we omit the compile-time assertion to avoid introducing a hard
 // dependency on gogo.
 func (id ID) Size() int {
 	return len([]byte(id))
@@ -59,12 +59,12 @@ func (id *ID) UnmarshalJSON(data []byte) (err error) {
 	return err
 }
 
-// TextMarshal returns the text encoding of the ID.
+// MarshalText returns the text encoding of the ID.
 func (id ID) MarshalText() ([]byte, error) {
 	return []byte(IDB58Encode(id)), nil
 }
 
-// TextUnmarshal restores the ID from its text encoding.
+// UnmarshalText restores the ID from its text encoding.
 func (id *ID) UnmarshalText(data []byte) error {
 	pid, err := IDB58Decode(string(data))
 	if err != nil {

--- a/peer/record.go
+++ b/peer/record.go
@@ -18,12 +18,12 @@ func init() {
 	record.RegisterType(&PeerRecord{})
 }
 
-// The domain string used for peer records contained in a Envelope.
+// PeerRecordEnvelopeDomain is the domain string used for peer records contained in a Envelope.
 const PeerRecordEnvelopeDomain = "libp2p-peer-record"
 
-// The type hint used to identify peer records in a Envelope.
+// PeerRecordEnvelopePayloadType is the type hint used to identify peer records in a Envelope.
 // Defined in https://github.com/multiformats/multicodec/blob/master/table.csv
-// with name "libp2p-peer-record"
+// with name "libp2p-peer-record".
 var PeerRecordEnvelopePayloadType = []byte{0x03, 0x01}
 
 // PeerRecord contains information that is broadly useful to share with other peers,

--- a/peer/set.go
+++ b/peer/set.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-// PeerSet is a threadsafe set of peers
+// PeerSet is a threadsafe set of peers.
 type Set struct {
 	lk sync.RWMutex
 	ps map[ID]struct{}

--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -22,7 +22,7 @@ var (
 	// AddressTTL is the expiration time of addresses.
 	AddressTTL = time.Hour
 
-	// TempAddrTTL is the ttl used for a short lived address
+	// TempAddrTTL is the ttl used for a short lived address.
 	TempAddrTTL = time.Minute * 2
 
 	// ProviderAddrTTL is the TTL of an address we've received from a provider.
@@ -115,10 +115,10 @@ type AddrBook interface {
 	// they will be sent along through the channel as well.
 	AddrStream(context.Context, peer.ID) <-chan ma.Multiaddr
 
-	// ClearAddresses removes all previously stored addresses
+	// ClearAddresses removes all previously stored addresses.
 	ClearAddrs(p peer.ID)
 
-	// PeersWithAddrs returns all of the peer IDs stored in the AddrBook
+	// PeersWithAddrs returns all of the peer IDs stored in the AddrBook.
 	PeersWithAddrs() peer.IDSlice
 }
 
@@ -159,7 +159,7 @@ type CertifiedAddrBook interface {
 	//
 	// If the signed PeerRecord belongs to a peer that already has certified
 	// addresses in the CertifiedAddrBook, the new addresses will replace the
-	// older ones, iff the new record has a higher sequence number than the
+	// older ones, if the new record has a higher sequence number than the
 	// existing record. Attempting to add a peer record with a
 	// sequence number that's <= an existing record for the same peer will not
 	// result in an error, but the record will be ignored, and the 'accepted'
@@ -227,7 +227,7 @@ type Metrics interface {
 	LatencyEWMA(peer.ID) time.Duration
 }
 
-// ProtoBook tracks the protocols supported by peers
+// ProtoBook tracks the protocols supported by peers.
 type ProtoBook interface {
 	GetProtocols(peer.ID) ([]string, error)
 	AddProtocols(peer.ID, ...string) error


### PR DESCRIPTION
After going through part of the code {connmgr, peer, peerstore}, I found a few inconsistencies on comment sentences.

Some comment sentences did not start with the name of the thing being described, and others did not end in a period, which causes inconsistent docs with the majority of libp2p docs and broader go ecosystem. [golang/go/wiki/CodeReviewComments#comment-sentences](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences) recommends that we do this, which we mostly do in the codebase.

Also fixed a minor typo.