### PR TITLE
API to get number of emitters for an event on the bus

### DIFF
--- a/event/bus.go
+++ b/event/bus.go
@@ -1,6 +1,8 @@
 package event
 
-import "io"
+import (
+	"io"
+)
 
 // SubscriptionOpt represents a subscriber option. Use the options exposed by the implementation of choice.
 type SubscriptionOpt = func(interface{}) error
@@ -71,4 +73,19 @@ type Bus interface {
 	//  defer em.Close() // MUST call this after being done with the emitter
 	//  em.Emit(EventT{})
 	Emitter(eventType interface{}, opts ...EmitterOpt) (Emitter, error)
+
+	// EmitterCount returns the number of Emitters for the given event type.
+	//
+	// eventType accepts typed nil pointers, and uses the type information for looking up the number of emitters.
+	//
+	// Example:
+	//  em, err := eventbus.Emitter(new(EventT))
+	//  defer em.Close()
+	//  eventbus.EmitterCount(new(EventT) == 1.
+	//  em2, err := eventbus.Emitter(new(EventT))
+	//  defer em2.Close()
+	//  eventbus.EmitterCount(new(EventT) == 2.
+	//
+	//
+	EmitterCount(eventType interface{}) (int, error)
 }

--- a/event/host.go
+++ b/event/host.go
@@ -1,0 +1,6 @@
+package event
+
+// EvtLocalHostInitialized is emitted when the local Host has been fully initialized.
+// Once this event is emitted by the Host, subscribers are guaranteed that the Host
+// has completely finished initializing and will not instantiate any new components.
+type EvtLocalHostInitialized struct{}


### PR DESCRIPTION
For https://github.com/libp2p/go-eventbus/issues/29.