### PR TITLE
feat: add a function to tell if a context subscribes to query events

### DIFF
--- a/routing/query.go
+++ b/routing/query.go
@@ -102,3 +102,10 @@ func PublishQueryEvent(ctx context.Context, ev *QueryEvent) {
 	ech := ich.(*eventChannel)
 	ech.send(ctx, ev)
 }
+
+// SubscribesToQueryEvents returns true if the context subscribes to query
+// events. If this function returns falls, calling `PublishQueryEvent` on the
+// context will be a no-op.
+func SubscribesToQueryEvents(ctx context.Context) bool {
+	return ctx.Value(routingQueryKey{}) != nil
+}


### PR DESCRIPTION
This can save us some work if the caller doesn't actually care about these events.