### PR TITLE
Interface to verify if a peer supports a protocol without making allocations

### DIFF
--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -238,7 +238,8 @@ type ProtoBook interface {
 	// If the returned error is not nil, the result is indeterminate.
 	SupportsProtocols(peer.ID, ...string) ([]string, error)
 
-	// SupportsAnyProtocol returns true if the peer supports ATLEAST ONE of the given protocols and false otherwise.
+	// FirstSupportedProtocol returns the first protocol that the peer supports among the given protocols.
+	// If the peer does not support any of the given protocols, this function will return an empty string and a nil error.
 	// If the returned error is not nil, the result is indeterminate.
-	SupportsAnyProtocol(peer.ID, ...string) (bool, error)
+	FirstSupportedProtocol(peer.ID, ...string) (string, error)
 }

--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -233,5 +233,12 @@ type ProtoBook interface {
 	AddProtocols(peer.ID, ...string) error
 	SetProtocols(peer.ID, ...string) error
 	RemoveProtocols(peer.ID, ...string) error
+
+	// SupportsProtocols returns the set of protocols the peer supports from among the given protocols.
+	// If the returned error is not nil, the result is indeterminate.
 	SupportsProtocols(peer.ID, ...string) ([]string, error)
+
+	// IsProtocolSupported returns true if the peer supports the given protocol and false otherwise.
+	// If the returned error is not nil, the result is indeterminate.
+	IsProtocolSupported(peer.ID, string) (bool, error)
 }

--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -238,7 +238,7 @@ type ProtoBook interface {
 	// If the returned error is not nil, the result is indeterminate.
 	SupportsProtocols(peer.ID, ...string) ([]string, error)
 
-	// IsProtocolSupported returns true if the peer supports the given protocol and false otherwise.
+	// SupportsAnyProtocol returns true if the peer supports ATLEAST ONE of the given protocols and false otherwise.
 	// If the returned error is not nil, the result is indeterminate.
-	IsProtocolSupported(peer.ID, string) (bool, error)
+	SupportsAnyProtocol(peer.ID, ...string) (bool, error)
 }


### PR DESCRIPTION
Motivation: https://github.com/libp2p/go-libp2p-kad-dht/issues/594.

In a lot of cases, we simply want to know if a peer supports any one protocol among a  set of protocols.
In such cases, we currently end up doing:

```
if s, err := as.host.Peerstore().SupportsProtocols(peer, protos...); 
len(s) == 0 && err == nil {...}
```

However, this causes needless allocations as `SupportsProtocols` makes an allocation for each protocol that is supported even if we don't actually need that information.

This PR adds a `SupportsAnyProtocol ` API that allows clients to determine if the peer supports ANY of the given protocols without knowing which of the given protocols it actually supports.