### PR TITLE
decaying tags: support removal and closure.

### DIFF
--- a/connmgr/decay.go
+++ b/connmgr/decay.go
@@ -70,6 +70,23 @@ type DecayingTag interface {
 	// will be applied asynchronously, and a non-nil error indicates a fault
 	// when queuing.
 	Bump(peer peer.ID, delta int) error
+
+	// Remove removes a decaying tag from a peer. The removal will be applied
+	// asynchronously, and a non-nil error indicates a fault when queuing.
+	Remove(peer peer.ID) error
+
+	// Close closes a decaying tag. The Decayer will stop tracking this tag,
+	// and the state of all peers in the Connection Manager holding this tag
+	// will be updated.
+	//
+	// The deletion is performed asynchronously.
+	//
+	// Once deleted, a tag should not be used, and further calls to Bump/Remove
+	// will error.
+	//
+	// Duplicate calls to Remove will not return errors, but a failure to queue
+	// the first actual removal, will (e.g. when the system is backlogged).
+	Close() error
 }
 
 // DecayingValue represents a value for a decaying tag.


### PR DESCRIPTION
This PR introduces two features to decaying tags:

* Explicitly remove a decaying tag from a peer.
* Kill/close a decaying tag, dropping its tracking and erasing it from all peers.

---

Implementation: https://github.com/libp2p/go-libp2p-connmgr/pull/72.