### PR TITLE
overhaul stream closure

### DIFF
--- a/mux/error.go
+++ b/mux/error.go
@@ -1,0 +1,49 @@
+package mux
+
+import (
+	"fmt"
+	"sync/atomic"
+)
+
+// StreamCloseError encapsulates error information that the application may
+// want to send to the peer when closing a stream.
+//
+// This data will be used on a best-effort basis. Not all stream muxers support
+// rich error signalling semantics.
+//
+// To check if the underlying muxer has effectively used the error details,
+// call the Used() method.
+//
+// Authors/maintainers of stream muxers can signal that the error has been used
+// by calling MarkUsed().
+type StreamCloseError struct {
+	Code   int
+	Reason error
+
+	// for alignment, this field is last, as the above two fields are
+	// likely one word each.
+	used int32
+}
+
+// Used returns whether the stream muxer has used any of the details of this
+// error.
+func (e *StreamCloseError) Used() bool {
+	return atomic.LoadInt32(&e.used) == 1
+}
+
+// MarkUsed allows a stream muxer to mark the details of this error as used.
+func (e *StreamCloseError) MarkUsed() {
+	atomic.StoreInt32(&e.used, 1)
+}
+
+func (e StreamCloseError) Unwrap() error {
+	return e.Reason
+}
+
+func (e StreamCloseError) Error() string {
+	msg := fmt.Sprintf("stream close error; code: %d", e.Code)
+	if e.Reason != nil {
+		msg = msg + "; err: " + e.Reason.Error()
+	}
+	return msg
+}

--- a/mux/error_test.go
+++ b/mux/error_test.go
@@ -1,0 +1,19 @@
+package mux
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestUnwrapStreamError(t *testing.T) {
+	foo := errors.New("foo")
+	sce := &StreamCloseError{
+		Code:   0,
+		Reason: foo,
+	}
+
+	err := errors.Unwrap(sce)
+	if err != foo {
+		t.Fatalf("expected unwrapped error to be: %s; was: %s", foo, err)
+	}
+}

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -19,9 +19,29 @@ type MuxedStream interface {
 	io.Reader
 	io.Writer
 
-	// Close closes the stream for writing. Reading will still work (that
-	// is, the remote side can still write).
+	// Close closes the stream.
+	//
+	// * Any buffered data for writing will be flushed.
+	// * Future reads will fail.
+	// * Any in-progress reads/writes will be interrupted.
+	//
+	// Close may be asynchronous and _does not_ guarantee receipt of the
+	// data.
 	io.Closer
+
+	// CloseWrite closes the stream for writing but leaves it open for
+	// reading.
+	//
+	// CloseWrite does not free the stream, users must still call Close or
+	// Reset.
+	CloseWrite() error
+
+	// CloseRead closes the stream for writing but leaves it open for
+	// reading.
+	//
+	// CloseRead does not free the stream, users must still call Close or
+	// Reset.
+	CloseRead() error
 
 	// Reset closes both ends of the stream. Use this to tell the remote
 	// side to hang up and go away.

--- a/mux/mux.go
+++ b/mux/mux.go
@@ -27,6 +27,9 @@ type MuxedStream interface {
 	//
 	// Close may be asynchronous and _does not_ guarantee receipt of the
 	// data.
+	//
+	// For adherence with Go conventions, the Close method does not accept
+	// a StreamCloseError. For a detailed
 	io.Closer
 
 	// CloseWrite closes the stream for writing but leaves it open for
@@ -34,18 +37,36 @@ type MuxedStream interface {
 	//
 	// CloseWrite does not free the stream, users must still call Close or
 	// Reset.
-	CloseWrite() error
+	//
+	// Users may provide an optional StreamCloseError, to convey a detailed
+	// error to the peer, if the underlying stream muxer supports so. To check
+	// if the underlying stream muxer has used the error, call
+	// StreamCloseError.Used() on return.
+	CloseWrite(err *StreamCloseError) error
 
-	// CloseRead closes the stream for writing but leaves it open for
-	// reading.
+	// CloseRead closes the stream for reading but leaves it open for
+	// writing.
 	//
 	// CloseRead does not free the stream, users must still call Close or
 	// Reset.
-	CloseRead() error
+	//
+	// Users may provide an optional StreamCloseError, to convey a detailed
+	// error to the peer, if the underlying stream muxer supports so. To check
+	// if the underlying stream muxer has used the error, call
+	// StreamCloseError.Used() on return.
+	CloseRead(err *StreamCloseError) error
 
-	// Reset closes both ends of the stream. Use this to tell the remote
-	// side to hang up and go away.
+	// Reset closes both ends of the stream abruptly. Use this to tell the
+	// remote side to hang up and go away.
 	Reset() error
+
+	// ResetErr closes both ends of the stream abruptly, allowing the user to
+	// specify an optional StreamCloseError. If nil, the behaviour is equivalent
+	// to Reset().
+	//
+	// To check if the underlying stream muxer has used the error call
+	// StreamCloseError.Used() on return.
+	ResetErr(err *StreamCloseError) error
 
 	SetDeadline(time.Time) error
 	SetReadDeadline(time.Time) error


### PR DESCRIPTION
_Carries over from #10._

---

This PR introduces interface changes to overhaul stream closure.

* `Close()` now behaves like `net.Conn#Close()`, closing the stream fully, with no abnormal termination. It flushes the write buffer, fails future reads, interrupts in-progress reads and writes.
* New `StreamCloseError` struct type to convey optional stream closure errors.
* New `CloseWrite(StreamCloseError)` method to close the write side of the stream only (equivalent to the current `Close()` behaviour -- a footgun for many).
* New `CloseRead(StreamCloseError)` method to close the read side of the stream only. Not all muxers support this; for those that don't this is equivalent to draining the read buffer into `io.Discard`.
* New `ResetErr(StreamCloseError)`, close a stream abnormally just like `Reset()`, but supports passing a `StreamCloseError`.