### PR TITLE
Connection Manager: add IsProtected interface

### DIFF
--- a/connmgr/manager.go
+++ b/connmgr/manager.go
@@ -70,6 +70,10 @@ type ConnManager interface {
 	// See notes on Protect() for more info.
 	Unprotect(id peer.ID, tag string) (protected bool)
 
+	// IsProtected returns true if the peer is protected for some tag; if the tag is the empty string
+	// then it will return true if the peer is protected for any tag
+	IsProtected(id peer.ID, tag string) (protected bool)
+
 	// Close closes the connection manager and stops background processes.
 	Close() error
 }

--- a/connmgr/null.go
+++ b/connmgr/null.go
@@ -20,4 +20,5 @@ func (_ NullConnMgr) TrimOpenConns(ctx context.Context)        {}
 func (_ NullConnMgr) Notifee() network.Notifiee                { return network.GlobalNoopNotifiee }
 func (_ NullConnMgr) Protect(peer.ID, string)                  {}
 func (_ NullConnMgr) Unprotect(peer.ID, string) bool           { return false }
+func (_ NullConnMgr) IsProtected(peer.ID, string) bool         { return false }
 func (_ NullConnMgr) Close() error                             { return nil }


### PR DESCRIPTION
So that we can query whether a peer is protected; especially useful for tests.