### PR TITLE
add a context to OpenStream and NewStream

### DIFF
--- a/mux/mux.go
+++ b/mux/mux.go
@@ -5,6 +5,7 @@
 package mux
 
 import (
+	"context"
 	"errors"
 	"io"
 	"net"
@@ -74,7 +75,7 @@ type MuxedConn interface {
 	IsClosed() bool
 
 	// OpenStream creates a new stream.
-	OpenStream() (MuxedStream, error)
+	OpenStream(context.Context) (MuxedStream, error)
 
 	// AcceptStream accepts a stream opened by the other side.
 	AcceptStream() (MuxedStream, error)

--- a/network/conn.go
+++ b/network/conn.go
@@ -1,6 +1,7 @@
 package network
 
 import (
+	"context"
 	"io"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
@@ -24,7 +25,7 @@ type Conn interface {
 	ID() string
 
 	// NewStream constructs a new Stream over this conn.
-	NewStream() (Stream, error)
+	NewStream(context.Context) (Stream, error)
 
 	// GetStreams returns all open streams over this conn.
 	GetStreams() []Stream


### PR DESCRIPTION
Fixes #86, using option 1.

Associated PRs (These PRs will all need to be rebased after we've merged this PR and cut a new release):

- https://github.com/libp2p/go-libp2p-swarm/pull/232
- https://github.com/libp2p/go-libp2p/pull/1033
- https://github.com/libp2p/go-libp2p-kad-dht/pull/701
- https://github.com/libp2p/go-libp2p-transport-upgrader/pull/70
- https://github.com/libp2p/go-libp2p-testing/pull/31
- https://github.com/libp2p/go-ws-transport/pull/98
- https://github.com/libp2p/go-libp2p-quic-transport/pull/189
- https://github.com/libp2p/go-libp2p-yamux/pull/29
- https://github.com/libp2p/go-libp2p-mplex/pull/21
- https://github.com/libp2p/go-libp2p-webrtc-direct/pull/35

