### PR TITLE
Event for user's NAT Device Type: Tell user if the node is behind an Easy or Hard NAT

### DIFF
--- a/event/nattype.go
+++ b/event/nattype.go
@@ -2,27 +2,6 @@ package event
 
 import "github.com/libp2p/go-libp2p-core/network"
 
-// NATTransportProtocol is the transport protocol for which the NAT Device Type has been determined.
-type NATTransportProtocol int
-
-const (
-	// NATTransportUDP means that the NAT Device Type has been determined for the UDP Protocol.
-	NATTransportUDP NATTransportProtocol = iota
-	// NATTransportTCP means that the NAT Device Type has been determined for the TCP Protocol.
-	NATTransportTCP
-)
-
-func (n NATTransportProtocol) String() string {
-	switch n {
-	case 0:
-		return "UDP"
-	case 1:
-		return "TCP"
-	default:
-		return "unrecognized"
-	}
-}
-
 // EvtNATDeviceTypeChanged is an event struct to be emitted when the type of the NAT device changes for a Transport Protocol.
 //
 // Note: This event is meaningful ONLY if the AutoNAT Reachability is Private.
@@ -30,7 +9,7 @@ func (n NATTransportProtocol) String() string {
 // this event ONLY if the Reachability on the `EvtLocalReachabilityChanged` is Private.
 type EvtNATDeviceTypeChanged struct {
 	// TransportProtocol is the Transport Protocol for which the NAT Device Type has been determined.
-	TransportProtocol NATTransportProtocol
+	TransportProtocol network.NATTransportProtocol
 	// NatDeviceType indicates the type of the NAT Device for the Transport Protocol.
 	// Currently, it can be either a `Cone NAT` or a `Symmetric NAT`. Please see the detailed documentation
 	// on `network.NATDeviceType` enumerations for a better understanding of what these types mean and

--- a/event/nattype.go
+++ b/event/nattype.go
@@ -12,6 +12,17 @@ const (
 	NATTransportTCP
 )
 
+func (n NATTransportProtocol) String() string {
+	switch n {
+	case 0:
+		return "UDP"
+	case 1:
+		return "TCP"
+	default:
+		return "unrecognized"
+	}
+}
+
 // EvtNATDeviceTypeChanged is an event struct to be emitted when the type of the NAT device changes for a Transport Protocol.
 //
 // Note: This event is meaningful ONLY if the AutoNAT Reachability is Private.

--- a/event/nattype.go
+++ b/event/nattype.go
@@ -2,7 +2,18 @@ package event
 
 import "github.com/libp2p/go-libp2p-core/network"
 
+// NATDeviceProtocol is the transport protocol for which the NAT Device Type has been determined.
+type NATDeviceProtocol int
+
+const (
+	// NATDeviceUDP means that the NAT Device Type has been determined for the UDP Protocol.
+	NATDeviceUDP NATDeviceProtocol = iota
+	// NATDeviceTCP means that the NAT Device Type has been determined for the TCP Protocol.
+	NATDeviceTCP
+)
+
 // EvtNATDeviceTypeChanged is an event struct to be emitted when the type of the NAT device changes.
 type EvtNATDeviceTypeChanged struct {
+	Protocol      NATDeviceProtocol
 	NatDeviceType network.NATDeviceType
 }

--- a/event/nattype.go
+++ b/event/nattype.go
@@ -1,0 +1,8 @@
+package event
+
+import "github.com/libp2p/go-libp2p-core/network"
+
+// EvtNATDeviceTypeChanged is an event struct to be emitted when the type of the NAT device changes.
+type EvtNATDeviceTypeChanged struct {
+	NatDeviceType network.NATDeviceType
+}

--- a/event/nattype.go
+++ b/event/nattype.go
@@ -2,18 +2,27 @@ package event
 
 import "github.com/libp2p/go-libp2p-core/network"
 
-// NATDeviceProtocol is the transport protocol for which the NAT Device Type has been determined.
-type NATDeviceProtocol int
+// NATTransportProtocol is the transport protocol for which the NAT Device Type has been determined.
+type NATTransportProtocol int
 
 const (
-	// NATDeviceUDP means that the NAT Device Type has been determined for the UDP Protocol.
-	NATDeviceUDP NATDeviceProtocol = iota
-	// NATDeviceTCP means that the NAT Device Type has been determined for the TCP Protocol.
-	NATDeviceTCP
+	// NATTransportUDP means that the NAT Device Type has been determined for the UDP Protocol.
+	NATTransportUDP NATTransportProtocol = iota
+	// NATTransportTCP means that the NAT Device Type has been determined for the TCP Protocol.
+	NATTransportTCP
 )
 
-// EvtNATDeviceTypeChanged is an event struct to be emitted when the type of the NAT device changes.
+// EvtNATDeviceTypeChanged is an event struct to be emitted when the type of the NAT device changes for a Transport Protocol.
+//
+// Note: This event is meaningful ONLY if the AutoNAT Reachability is Private.
+// Consumers of this event should ALSO consume the `EvtLocalReachabilityChanged` event and interpret
+// this event ONLY if the Reachability on the `EvtLocalReachabilityChanged` is Private.
 type EvtNATDeviceTypeChanged struct {
-	Protocol      NATDeviceProtocol
+	// TransportProtocol is the Transport Protocol for which the NAT Device Type has been determined.
+	TransportProtocol NATTransportProtocol
+	// NatDeviceType indicates the type of the NAT Device for the Transport Protocol.
+	// Currently, it can be either a `Cone NAT` or a `Symmetric NAT`. Please see the detailed documentation
+	// on `network.NATDeviceType` enumerations for a better understanding of what these types mean and
+	// how they impact Connectivity and Hole Punching.
 	NatDeviceType network.NATDeviceType
 }

--- a/network/nattype.go
+++ b/network/nattype.go
@@ -15,7 +15,7 @@ const (
 	// NAT traversal with hole punching is possible with a Cone NAT if the remote peer is ALSO behind a Cone NAT.
 	NATDeviceTypeCone
 
-	// NATDeviceTypeHard indicates that the NAT device is a Symmetric NAT.
+	// NATDeviceTypeSymmetric indicates that the NAT device is a Symmetric NAT.
 	// A Symmetric NAT maps outgoing connections with different destination addresses to different IP addresses and ports
 	// even if they originate from the same source IP address and port.
 	// NAT traversal with hole-punching is currently NOT possible in libp2p with Symmetric NATs irrespective of the remote peer's NAT type.

--- a/network/nattype.go
+++ b/network/nattype.go
@@ -12,7 +12,8 @@ const (
 	// to the same IP address and port irrespective of the destination address.
 	// With regards to RFC 3489, this could be either a Full Cone NAT, a Restricted Cone NAT or a
 	// Port Restricted Cone NAT. However, we do NOT differentiate between them here and simply classify all such NATs as a Cone NAT.
-	// NAT traversal with hole punching is possible with a Cone NAT if the remote peer is ALSO behind a Cone NAT.
+	// NAT traversal with hole punching is possible with a Cone NAT ONLY if the remote peer is ALSO behind a Cone NAT.
+	// If the remote peer is behind a Symmetric NAT, hole punching will fail.
 	NATDeviceTypeCone
 
 	// NATDeviceTypeSymmetric indicates that the NAT device is a Symmetric NAT.
@@ -23,9 +24,14 @@ const (
 )
 
 func (r NATDeviceType) String() string {
-	str := [...]string{"Unknown", "Cone", "Symmetric"}
-	if r < 0 || int(r) >= len(str) {
-		return "(unrecognized)"
+	switch r {
+	case 0:
+		return "Unknown"
+	case 1:
+		return "Cone"
+	case 2:
+		return "Symmetric"
+	default:
+		return "unrecognized"
 	}
-	return str[r]
 }

--- a/network/nattype.go
+++ b/network/nattype.go
@@ -1,24 +1,29 @@
 package network
 
-// NATDeviceType indicates the type of the NAT device i.e. whether it is a Hard or an Easy NAT.
+// NATDeviceType indicates the type of the NAT device.
 type NATDeviceType int
 
 const (
 	// NATDeviceTypeUnknown indicates that the type of the NAT device is unknown.
 	NATDeviceTypeUnknown NATDeviceType = iota
 
-	// NATDeviceTypeEasy indicates that the NAT device is an Easy NAT i.e. it supports consistent endpoint translation.
-	// NAT traversal via hole punching is possible with this NAT type if the remote peer is also behind an Easy NAT.
-	NATDeviceTypeEasy
+	// NATDeviceTypeCone indicates that the NAT device is a Cone NAT.
+	// A Cone NAT is a NAT where all outgoing connections from the same source IP address and port are mapped by the NAT device
+	// to the same IP address and port irrespective of the destination address.
+	// With Regards to Internet Society RFC 3489, this could be either a Full Cone NAT, a Restricted Cone NAT or a
+	// Port Restricted Cone NAT. However, we do NOT differentiate between them here and simply classify all such NATs as a Cone NAT.
+	// NAT traversal with hole punching is possible with a Cone NAT if the remote peer is ALSO behind a Cone NAT.
+	NATDeviceTypeCone
 
-	// NATDeviceTypeHard indicates that the NAT device is a Hard NAT that does NOT support
-	// consistent endpoint translation.
-	// NAT traversal via hole-punching is NOT possible with this NAT type irrespective of the remote peer's NAT type.
-	NATDeviceTypeHard
+	// NATDeviceTypeHard indicates that the NAT device is a Symmetric NAT.
+	// A Symmetric NAT maps outgoing connections with different destination addresses to different IP addresses and ports
+	// even if they originate from the same source IP address and port.
+	// NAT traversal with hole-punching is currently NOT possible in libp2p with Symmetric NATs irrespective of the remote peer's NAT type.
+	NATDeviceTypeSymmetric
 )
 
 func (r NATDeviceType) String() string {
-	str := [...]string{"Unknown", "Easy", "Hard"}
+	str := [...]string{"Unknown", "Cone", "Symmetric"}
 	if r < 0 || int(r) >= len(str) {
 		return "(unrecognized)"
 	}

--- a/network/nattype.go
+++ b/network/nattype.go
@@ -1,0 +1,18 @@
+package network
+
+// NATDeviceType indicates the type of the NAT device i.e. whether it is a Hard or an Easy NAT.
+type NATDeviceType int
+
+const (
+	// NATDeviceTypeUnknown indicates that the type of the NAT device is unknown.
+	NATDeviceTypeUnknown NATDeviceType = iota
+
+	// NATDeviceTypeEasy indicates that the NAT device is an Easy NAT i.e. it supports consistent endpoint translation.
+	// NAT traversal via hole punching is possible with this NAT type if the remote peer is also behind an Easy NAT.
+	NATDeviceTypeEasy
+
+	// NATDeviceTypeHard indicates that the NAT device is a Hard NAT that does NOT support
+	// consistent endpoint translation.
+	// NAT traversal via hole-punching is NOT possible with this NAT type irrespective of the remote peer's NAT type.
+	NATDeviceTypeHard
+)

--- a/network/nattype.go
+++ b/network/nattype.go
@@ -16,7 +16,7 @@ const (
 	NATDeviceTypeCone
 
 	// NATDeviceTypeSymmetric indicates that the NAT device is a Symmetric NAT.
-	// A Symmetric NAT maps outgoing connections with different destination addresses to different IP addresses and ports
+	// A Symmetric NAT maps outgoing connections with different destination addresses to different IP addresses and ports,
 	// even if they originate from the same source IP address and port.
 	// NAT traversal with hole-punching is currently NOT possible in libp2p with Symmetric NATs irrespective of the remote peer's NAT type.
 	NATDeviceTypeSymmetric

--- a/network/nattype.go
+++ b/network/nattype.go
@@ -10,7 +10,7 @@ const (
 	// NATDeviceTypeCone indicates that the NAT device is a Cone NAT.
 	// A Cone NAT is a NAT where all outgoing connections from the same source IP address and port are mapped by the NAT device
 	// to the same IP address and port irrespective of the destination address.
-	// With Regards to Internet Society RFC 3489, this could be either a Full Cone NAT, a Restricted Cone NAT or a
+	// With regards to RFC 3489, this could be either a Full Cone NAT, a Restricted Cone NAT or a
 	// Port Restricted Cone NAT. However, we do NOT differentiate between them here and simply classify all such NATs as a Cone NAT.
 	// NAT traversal with hole punching is possible with a Cone NAT if the remote peer is ALSO behind a Cone NAT.
 	NATDeviceTypeCone

--- a/network/nattype.go
+++ b/network/nattype.go
@@ -35,3 +35,24 @@ func (r NATDeviceType) String() string {
 		return "unrecognized"
 	}
 }
+
+// NATTransportProtocol is the transport protocol for which the NAT Device Type has been determined.
+type NATTransportProtocol int
+
+const (
+	// NATTransportUDP means that the NAT Device Type has been determined for the UDP Protocol.
+	NATTransportUDP NATTransportProtocol = iota
+	// NATTransportTCP means that the NAT Device Type has been determined for the TCP Protocol.
+	NATTransportTCP
+)
+
+func (n NATTransportProtocol) String() string {
+	switch n {
+	case 0:
+		return "UDP"
+	case 1:
+		return "TCP"
+	default:
+		return "unrecognized"
+	}
+}

--- a/network/nattype.go
+++ b/network/nattype.go
@@ -16,3 +16,11 @@ const (
 	// NAT traversal via hole-punching is NOT possible with this NAT type irrespective of the remote peer's NAT type.
 	NATDeviceTypeHard
 )
+
+func (r NATDeviceType) String() string {
+	str := [...]string{"Unknown", "Easy", "Hard"}
+	if r < 0 || int(r) >= len(str) {
+		return "(unrecognized)"
+	}
+	return str[r]
+}


### PR DESCRIPTION
For https://github.com/libp2p/go-libp2p/issues/1039.

Emit event to inform user of the NAT Device Type wrt BAT traversal i.e. Easy NAT(supports consistent endpoint translation) or Hard NAT(does NOT support consistent endpoint translation).