### PR TITLE
add support for transient connections

### DIFF
--- a/network/conn.go
+++ b/network/conn.go
@@ -60,6 +60,7 @@ type ConnMultiaddrs interface {
 	RemoteMultiaddr() ma.Multiaddr
 }
 
+// ConnStat is an interface mixin for connection types that provide connection statistics.
 type ConnStat interface {
 	// Stat stores metadata pertaining to this conn.
 	Stat() Stat

--- a/network/conn.go
+++ b/network/conn.go
@@ -19,6 +19,7 @@ type Conn interface {
 
 	ConnSecurity
 	ConnMultiaddrs
+	ConnStat
 
 	// ID returns an identifier that uniquely identifies this Conn within this
 	// host, during this run. Connection IDs may repeat across restarts.
@@ -29,9 +30,6 @@ type Conn interface {
 
 	// GetStreams returns all open streams over this conn.
 	GetStreams() []Stream
-
-	// Stat stores metadata pertaining to this conn.
-	Stat() Stat
 }
 
 // ConnSecurity is the interface that one can mix into a connection interface to
@@ -60,4 +58,9 @@ type ConnMultiaddrs interface {
 	// RemoteMultiaddr returns the remote Multiaddr associated
 	// with this connection
 	RemoteMultiaddr() ma.Multiaddr
+}
+
+type ConnStat interface {
+	// Stat stores metadata pertaining to this conn.
+	Stat() Stat
 }

--- a/network/context.go
+++ b/network/context.go
@@ -69,7 +69,7 @@ func WithDialPeerTimeout(ctx context.Context, timeout time.Duration) context.Con
 	return context.WithValue(ctx, dialPeerTimeoutCtxKey{}, timeout)
 }
 
-// WithUseTransient constructs a new context with an option that instructs to network
+// WithUseTransient constructs a new context with an option that instructs the network
 // that it is acceptable to use a transient connection when opening a new stream.
 func WithUseTransient(ctx context.Context) context.Context {
 	return context.WithValue(ctx, useTransient, true)

--- a/network/context.go
+++ b/network/context.go
@@ -13,9 +13,11 @@ var DialPeerTimeout = 60 * time.Second
 type noDialCtxKey struct{}
 type dialPeerTimeoutCtxKey struct{}
 type forceDirectDialCtxKey struct{}
+type useTransientCtxKey struct{}
 
 var noDial = noDialCtxKey{}
 var forceDirectDial = forceDirectDialCtxKey{}
+var useTransient = useTransientCtxKey{}
 
 // EXPERIMENTAL
 // WithForceDirectDial constructs a new context with an option that instructs the network
@@ -65,4 +67,19 @@ func GetDialPeerTimeout(ctx context.Context) time.Duration {
 // independently.
 func WithDialPeerTimeout(ctx context.Context, timeout time.Duration) context.Context {
 	return context.WithValue(ctx, dialPeerTimeoutCtxKey{}, timeout)
+}
+
+// WithUseTransient constructs a new context with an option that instructs to network
+// that it is acceptable to use a transient connection when opening a new stream.
+func WithUseTransient(ctx context.Context) context.Context {
+	return context.WithValue(ctx, useTransient, true)
+}
+
+// GetUseTransient returns true if the use transient option is set in the context.
+func GetUseTransient(ctx context.Context) bool {
+	v := ctx.Value(useTransient)
+	if v != nil {
+		return true
+	}
+	return false
 }

--- a/network/context.go
+++ b/network/context.go
@@ -71,15 +71,15 @@ func WithDialPeerTimeout(ctx context.Context, timeout time.Duration) context.Con
 
 // WithUseTransient constructs a new context with an option that instructs the network
 // that it is acceptable to use a transient connection when opening a new stream.
-func WithUseTransient(ctx context.Context) context.Context {
-	return context.WithValue(ctx, useTransient, true)
+func WithUseTransient(ctx context.Context, reason string) context.Context {
+	return context.WithValue(ctx, useTransient, reason)
 }
 
 // GetUseTransient returns true if the use transient option is set in the context.
-func GetUseTransient(ctx context.Context) bool {
+func GetUseTransient(ctx context.Context) (usetransient bool, reason string) {
 	v := ctx.Value(useTransient)
 	if v != nil {
-		return true
+		return true, v.(string)
 	}
-	return false
+	return false, ""
 }

--- a/network/errors.go
+++ b/network/errors.go
@@ -8,3 +8,7 @@ var ErrNoRemoteAddrs = errors.New("no remote addresses")
 // ErrNoConn is returned when attempting to open a stream to a peer with the NoDial
 // option and no usable connection is available.
 var ErrNoConn = errors.New("no usable connection to peer")
+
+// ErrTransientConn is returned when attempting to open a stream to a peer with only a transient
+// connection, without specifying the UseTransient option.
+var ErrTransientConn = errors.New("transient connection to peer")

--- a/network/network.go
+++ b/network/network.go
@@ -103,6 +103,8 @@ type Stat struct {
 	Direction Direction
 	// Opened is the timestamp when this connection was opened.
 	Opened time.Time
+	// Transient indicates that this connection is transient and may be closed soon
+	Transient bool
 	// Extra stores additional metadata about this connection.
 	Extra map[interface{}]interface{}
 }

--- a/network/network.go
+++ b/network/network.go
@@ -103,7 +103,7 @@ type Stat struct {
 	Direction Direction
 	// Opened is the timestamp when this connection was opened.
 	Opened time.Time
-	// Transient indicates that this connection is transient and may be closed soon
+	// Transient indicates that this connection is transient and may be closed soon.
 	Transient bool
 	// Extra stores additional metadata about this connection.
 	Extra map[interface{}]interface{}


### PR DESCRIPTION
It adds a transient mark in the metadata and a context option to opt-in for opening streams on transient connections.