### PR TITLE
refactor: use a helper type to decode AddrInfo from JSON

### DIFF
--- a/peer/addrinfo_test.go
+++ b/peer/addrinfo_test.go
@@ -133,3 +133,21 @@ func TestAddrInfosFromP2pAddrs(t *testing.T) {
 		delete(expected, info.ID.Pretty())
 	}
 }
+
+func TestAddrInfoJSON(t *testing.T) {
+	ai := AddrInfo{ID: testID, Addrs: []ma.Multiaddr{maddrFull}}
+	out, err := ai.MarshalJSON()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var addrInfo AddrInfo
+	if err := addrInfo.UnmarshalJSON(out); err != nil {
+		t.Fatal(err)
+	}
+	if addrInfo.ID != testID {
+		t.Fatalf("expected ID to equal %s, got %s", testID.Pretty(), addrInfo.ID.Pretty())
+	}
+	if len(addrInfo.Addrs) != 1 || !addrInfo.Addrs[0].Equal(maddrFull) {
+		t.Fatalf("expected addrs to match %v, got %v", maddrFull, addrInfo.Addrs)
+	}
+}


### PR DESCRIPTION
This saves us a bunch of error prone manual decode/encode logic.