### PR TITLE
make it possible to change ID Hash

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -13,6 +13,10 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
+var DefaultIDHash uint64 = mh.SHA2_256
+var DefaultHashPrefix = "Qm"
+var DefaultIdentityPrefix = "1"
+
 var (
 	// ErrEmptyPeerID is an error for empty peer ID.
 	ErrEmptyPeerID = errors.New("empty peer ID")
@@ -170,7 +174,7 @@ func IDHexEncode(id ID) string {
 // The encoded peer ID can either be a CID of a key or a raw multihash (identity
 // or sha256-256).
 func Decode(s string) (ID, error) {
-	if strings.HasPrefix(s, "Qm") || strings.HasPrefix(s, "1") {
+	if strings.HasPrefix(s, DefaultHashPrefix) || strings.HasPrefix(s, DefaultIdentityPrefix) {
 		// base58 encoded sha256 or identity multihash
 		m, err := mh.FromB58String(s)
 		if err != nil {
@@ -224,7 +228,7 @@ func IDFromPublicKey(pk ic.PubKey) (ID, error) {
 	if err != nil {
 		return "", err
 	}
-	var alg uint64 = mh.SHA2_256
+	var alg uint64 = DefaultIDHash
 	if AdvancedEnableInlining && len(b) <= maxInlineKeyLength {
 		alg = mh.IDENTITY
 	}

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -20,7 +20,7 @@ var gen2 keyset // generated
 var man keyset  // manual
 
 func hash(b []byte) []byte {
-	h, _ := mh.Sum(b, mh.SHA2_256, -1)
+	h, _ := mh.Sum(b, DefaultIDHash, -1)
 	return []byte(h)
 }
 

--- a/test/peer.go
+++ b/test/peer.go
@@ -12,7 +12,7 @@ import (
 func RandPeerID() (peer.ID, error) {
 	buf := make([]byte, 16)
 	rand.Read(buf)
-	h, _ := mh.Sum(buf, mh.SHA2_256, -1)
+	h, _ := mh.Sum(buf, peer.DefaultIDHash, -1)
 	return peer.ID(h), nil
 }
 


### PR DESCRIPTION
By adjusting these hard-coded parameters to changeable global variables, the code calling go-libp2p-core can change these parameters to meet the requirements.