### PR TITLE
remove flaky tests

### DIFF
--- a/metrics/bandwidth_test.go
+++ b/metrics/bandwidth_test.go
@@ -113,23 +113,6 @@ func TestBandwidthCounter(t *testing.T) {
 
 	time.Sleep(time.Second)
 	close(start)
-	time.Sleep(2*time.Second + 100*time.Millisecond)
-
-	assertPeers(func(stats Stats) {
-		assertApproxEq(t, 2000, stats.RateOut)
-		assertApproxEq(t, 1000, stats.RateIn)
-	})
-
-	assertProtocols(func(stats Stats) {
-		assertApproxEq(t, 100000, stats.RateOut)
-		assertApproxEq(t, 50000, stats.RateIn)
-	})
-
-	{
-		stats := bwc.GetBandwidthTotals()
-		assertApproxEq(t, 200000, stats.RateOut)
-		assertApproxEq(t, 100000, stats.RateIn)
-	}
 
 	wg.Wait()
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
These tests regularly failed to stay within the 1% of the expected threshold. These tests are taken after 2.1 seconds on the wall, but before the wait-group has finished, but I think on many systems the timers are not accurate to be used reliabily within tight 

On my system (kernel configured with CONFIG_HZ=300) each tick may be inaccurate by more than 3ms, over 40 iterations the error might be as high as 1.6% for each goroutine


I chose to delete these tests because figuring out the right error threashold seems a little too magical to me, but if there's a good reason to keep these tests I can change htis PR to just increase the error threshold. 