### PR TITLE
remove minimum Go version from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 
 > Home to the interfaces and abstractions that make up go-libp2p.
 
-Minimum go version: 1.13
 
 ## Install
 


### PR DESCRIPTION
It's incorrect, and I'm sure we'll forget updating it every half a year. Better to say nothing.