### PR TITLE
fix: make timestamps strictly increasing

### DIFF
--- a/peer/record_test.go
+++ b/peer/record_test.go
@@ -56,11 +56,11 @@ func TestSignedPeerRecordFromEnvelope(t *testing.T) {
 // This is pretty much guaranteed to pass on Linux no matter how we implement it, but Windows has
 // low clock precision. This makes sure we never get a duplicate.
 func TestTimestampSeq(t *testing.T) {
-	last := uint64(0)
+	var last uint64
 	for i := 0; i < 1000; i++ {
 		next := TimestampSeq()
 		if next <= last {
-			t.Errorf("non-increasing timestampfound: %d <= %d", next, last)
+			t.Errorf("non-increasing timestamp found: %d <= %d", next, last)
 		}
 		last = next
 	}

--- a/peer/record_test.go
+++ b/peer/record_test.go
@@ -52,3 +52,16 @@ func TestSignedPeerRecordFromEnvelope(t *testing.T) {
 		}
 	})
 }
+
+// This is pretty much guaranteed to pass on Linux no matter how we implement it, but Windows has
+// low clock precision. This makes sure we never get a duplicate.
+func TestTimestampSeq(t *testing.T) {
+	last := uint64(0)
+	for i := 0; i < 1000; i++ {
+		next := TimestampSeq()
+		if next <= last {
+			t.Errorf("non-increasing timestampfound: %d <= %d", next, last)
+		}
+		last = next
+	}
+}


### PR DESCRIPTION
On Linux, this is almost always the case. Windows, however, doesn't have nanosecond accuracy.

We make the timestamp sequence numbers strictly increasing by returning the last timestamp + 1 where necessary.