### PR TITLE
feat: add helper functions for working with addr infos

### DIFF
--- a/peer/addrinfo.go
+++ b/peer/addrinfo.go
@@ -106,3 +106,12 @@ func (pi *AddrInfo) Loggable() map[string]interface{} {
 		"addrs":  pi.Addrs,
 	}
 }
+
+// AddrInfosToIDs extracts the peer IDs from the passed AddrInfos and returns them in-order.
+func AddrInfosToIDs(pis []AddrInfo) []ID {
+	ps := make([]ID, len(pis))
+	for i, pi := range pis {
+		ps[i] = pi.ID
+	}
+	return ps
+}

--- a/peerstore/helpers.go
+++ b/peerstore/helpers.go
@@ -1,0 +1,14 @@
+package peerstore
+
+import (
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+// AddrInfos returns an AddrInfo for each specified peer ID, in-order.
+func AddrInfos(ps Peerstore, peers []peer.ID) []peer.AddrInfo {
+	pi := make([]peer.AddrInfo, len(peers))
+	for i, p := range peers {
+		pi[i] = ps.PeerInfo(p)
+	}
+	return pi
+}


### PR DESCRIPTION
Specifically, move them _here_ from the peerstore. That way packages (like the DHT) that currently directly rely on the peerstore, can just use go-libp2p-core.

Moved from https://github.com/libp2p/go-libp2p-peerstore/blob/f7f22569f7d49635953638ffb11915dd3d054cf5/peerstore.go#L79-L93

With some small modifications.