### PR TITLE
remove deprecated Bytes method from the Key interface

### DIFF
--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -12,7 +12,7 @@ import (
 
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 
-	sha256 "github.com/minio/sha256-simd"
+	"github.com/minio/sha256-simd"
 )
 
 // ECDSAPrivateKey is an implementation of an ECDSA private key
@@ -102,11 +102,6 @@ func UnmarshalECDSAPublicKey(data []byte) (PubKey, error) {
 	return &ECDSAPublicKey{pub}, nil
 }
 
-// Bytes returns the private key as protobuf bytes
-func (ePriv *ECDSAPrivateKey) Bytes() ([]byte, error) {
-	return MarshalPrivateKey(ePriv)
-}
-
 // Type returns the key type
 func (ePriv *ECDSAPrivateKey) Type() pb.KeyType {
 	return pb.KeyType_ECDSA
@@ -139,11 +134,6 @@ func (ePriv *ECDSAPrivateKey) Sign(data []byte) ([]byte, error) {
 // GetPublic returns a public key
 func (ePriv *ECDSAPrivateKey) GetPublic() PubKey {
 	return &ECDSAPublicKey{&ePriv.priv.PublicKey}
-}
-
-// Bytes returns the public key as protobuf bytes
-func (ePub *ECDSAPublicKey) Bytes() ([]byte, error) {
-	return MarshalPublicKey(ePub)
 }
 
 // Type returns the key type

--- a/crypto/ecdsa_test.go
+++ b/crypto/ecdsa_test.go
@@ -66,7 +66,7 @@ func TestECDSAMarshalLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	privB, err := priv.Bytes()
+	privB, err := MarshalPrivateKey(priv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestECDSAMarshalLoop(t *testing.T) {
 		t.Fatal("keys are not equal")
 	}
 
-	pubB, err := pub.Bytes()
+	pubB, err := MarshalPublicKey(pub)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/crypto/ed25519.go
+++ b/crypto/ed25519.go
@@ -42,11 +42,6 @@ func (k *Ed25519PrivateKey) Type() pb.KeyType {
 	return pb.KeyType_Ed25519
 }
 
-// Bytes marshals an ed25519 private key to protobuf bytes.
-func (k *Ed25519PrivateKey) Bytes() ([]byte, error) {
-	return MarshalPrivateKey(k)
-}
-
 // Raw private key bytes.
 func (k *Ed25519PrivateKey) Raw() ([]byte, error) {
 	// The Ed25519 private key contains two 32-bytes curve points, the private
@@ -86,11 +81,6 @@ func (k *Ed25519PrivateKey) Sign(msg []byte) ([]byte, error) {
 // Type of the public key (Ed25519).
 func (k *Ed25519PublicKey) Type() pb.KeyType {
 	return pb.KeyType_Ed25519
-}
-
-// Bytes returns a ed25519 public key as protobuf bytes.
-func (k *Ed25519PublicKey) Bytes() ([]byte, error) {
-	return MarshalPublicKey(k)
 }
 
 // Raw public key bytes.

--- a/crypto/ed25519_test.go
+++ b/crypto/ed25519_test.go
@@ -71,7 +71,6 @@ func TestMarshalLoop(t *testing.T) {
 
 	t.Run("PrivateKey", func(t *testing.T) {
 		for name, f := range map[string]func() ([]byte, error){
-			"Bytes": priv.Bytes,
 			"Marshal": func() ([]byte, error) {
 				return MarshalPrivateKey(priv)
 			},
@@ -126,7 +125,6 @@ func TestMarshalLoop(t *testing.T) {
 
 	t.Run("PublicKey", func(t *testing.T) {
 		for name, f := range map[string]func() ([]byte, error){
-			"Bytes": pub.Bytes,
 			"Marshal": func() ([]byte, error) {
 				return MarshalPublicKey(pub)
 			},

--- a/crypto/fixture_test.go
+++ b/crypto/fixture_test.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"testing"
 
-	crypto "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/crypto"
 	crypto_pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 )
 
@@ -62,7 +62,7 @@ func TestFixtures(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			pubBytes2, err := pub.Bytes()
+			pubBytes2, err := crypto.MarshalPublicKey(pub)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,7 +73,7 @@ func TestFixtures(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			privBytes2, err := priv.Bytes()
+			privBytes2, err := crypto.MarshalPrivateKey(priv)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -113,11 +113,11 @@ func generate() {
 		if err != nil {
 			panic(err)
 		}
-		pubb, err := pub.Bytes()
+		pubb, err := crypto.MarshalPublicKey(pub)
 		if err != nil {
 			panic(err)
 		}
-		privb, err := priv.Bytes()
+		privb, err := crypto.MarshalPrivateKey(priv)
 		if err != nil {
 			panic(err)
 		}

--- a/crypto/key.go
+++ b/crypto/key.go
@@ -19,7 +19,7 @@ import (
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 
 	"github.com/gogo/protobuf/proto"
-	sha256 "github.com/minio/sha256-simd"
+	"github.com/minio/sha256-simd"
 )
 
 const (
@@ -69,10 +69,6 @@ var PrivKeyUnmarshallers = map[pb.KeyType]PrivKeyUnmarshaller{
 
 // Key represents a crypto key that can be compared to another key
 type Key interface {
-	// Bytes returns a serialized, storeable representation of this key
-	// DEPRECATED in favor of Marshal / Unmarshal
-	Bytes() ([]byte, error)
-
 	// Equals checks whether two PubKeys are the same
 	Equals(Key) bool
 
@@ -82,7 +78,7 @@ type Key interface {
 	// This function is the inverse of {Priv,Pub}KeyUnmarshaler.
 	Raw() ([]byte, error)
 
-	// Type returns the protobof key type.
+	// Type returns the protobuf key type.
 	Type() pb.KeyType
 }
 

--- a/crypto/openssl_common.go
+++ b/crypto/openssl_common.go
@@ -7,7 +7,7 @@ import (
 
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 
-	openssl "github.com/libp2p/go-openssl"
+	"github.com/libp2p/go-openssl"
 )
 
 // define these as separate types so we can add more key types later and reuse
@@ -55,17 +55,6 @@ func (pk *opensslPublicKey) Type() pb.KeyType {
 	}
 }
 
-// Bytes returns protobuf bytes of a public key
-func (pk *opensslPublicKey) Bytes() ([]byte, error) {
-	pk.cacheLk.Lock()
-	var err error
-	if pk.cached == nil {
-		pk.cached, err = MarshalPublicKey(pk)
-	}
-	pk.cacheLk.Unlock()
-	return pk.cached, err
-}
-
 func (pk *opensslPublicKey) Raw() ([]byte, error) {
 	return pk.key.MarshalPKIXPublicKeyDER()
 }
@@ -97,11 +86,6 @@ func (sk *opensslPrivateKey) Type() pb.KeyType {
 	default:
 		return -1
 	}
-}
-
-// Bytes returns protobuf bytes from a private key
-func (sk *opensslPrivateKey) Bytes() ([]byte, error) {
-	return MarshalPrivateKey(sk)
 }
 
 func (sk *opensslPrivateKey) Raw() ([]byte, error) {

--- a/crypto/rsa_go.go
+++ b/crypto/rsa_go.go
@@ -9,7 +9,6 @@ import (
 	"crypto/x509"
 	"errors"
 	"io"
-	"sync"
 
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 
@@ -25,8 +24,7 @@ type RsaPrivateKey struct {
 type RsaPublicKey struct {
 	k rsa.PublicKey
 
-	cacheLk sync.Mutex
-	cached  []byte
+	cached []byte
 }
 
 // GenerateRSAKeyPair generates a new rsa private and public key
@@ -54,17 +52,6 @@ func (pk *RsaPublicKey) Verify(data, sig []byte) (bool, error) {
 
 func (pk *RsaPublicKey) Type() pb.KeyType {
 	return pb.KeyType_RSA
-}
-
-// Bytes returns protobuf bytes of a public key
-func (pk *RsaPublicKey) Bytes() ([]byte, error) {
-	pk.cacheLk.Lock()
-	var err error
-	if pk.cached == nil {
-		pk.cached, err = MarshalPublicKey(pk)
-	}
-	pk.cacheLk.Unlock()
-	return pk.cached, err
 }
 
 func (pk *RsaPublicKey) Raw() ([]byte, error) {
@@ -95,11 +82,6 @@ func (sk *RsaPrivateKey) GetPublic() PubKey {
 
 func (sk *RsaPrivateKey) Type() pb.KeyType {
 	return pb.KeyType_RSA
-}
-
-// Bytes returns protobuf bytes from a private key
-func (sk *RsaPrivateKey) Bytes() ([]byte, error) {
-	return MarshalPrivateKey(sk)
 }
 
 func (sk *RsaPrivateKey) Raw() ([]byte, error) {

--- a/crypto/rsa_test.go
+++ b/crypto/rsa_test.go
@@ -95,7 +95,7 @@ func TestRSAMarshalLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	privB, err := priv.Bytes()
+	privB, err := MarshalPrivateKey(priv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestRSAMarshalLoop(t *testing.T) {
 		t.Fatal("keys are not equal")
 	}
 
-	pubB, err := pub.Bytes()
+	pubB, err := MarshalPublicKey(pub)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/crypto/secp256k1.go
+++ b/crypto/secp256k1.go
@@ -6,8 +6,8 @@ import (
 
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 
-	btcec "github.com/btcsuite/btcd/btcec"
-	sha256 "github.com/minio/sha256-simd"
+	"github.com/btcsuite/btcd/btcec"
+	"github.com/minio/sha256-simd"
 )
 
 // Secp256k1PrivateKey is an Secp256k1 private key
@@ -47,11 +47,6 @@ func UnmarshalSecp256k1PublicKey(data []byte) (PubKey, error) {
 	return (*Secp256k1PublicKey)(k), nil
 }
 
-// Bytes returns protobuf bytes from a private key
-func (k *Secp256k1PrivateKey) Bytes() ([]byte, error) {
-	return MarshalPrivateKey(k)
-}
-
 // Type returns the private key type
 func (k *Secp256k1PrivateKey) Type() pb.KeyType {
 	return pb.KeyType_Secp256k1
@@ -86,11 +81,6 @@ func (k *Secp256k1PrivateKey) Sign(data []byte) ([]byte, error) {
 // GetPublic returns a public key
 func (k *Secp256k1PrivateKey) GetPublic() PubKey {
 	return (*Secp256k1PublicKey)((*btcec.PrivateKey)(k).PubKey())
-}
-
-// Bytes returns protobuf bytes from a public key
-func (k *Secp256k1PublicKey) Bytes() ([]byte, error) {
-	return MarshalPublicKey(k)
 }
 
 // Type returns the public key type

--- a/crypto/secp256k1_test.go
+++ b/crypto/secp256k1_test.go
@@ -66,7 +66,7 @@ func TestSecp256k1MarshalLoop(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	privB, err := priv.Bytes()
+	privB, err := MarshalPrivateKey(priv)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestSecp256k1MarshalLoop(t *testing.T) {
 		t.Fatal("keys are not equal")
 	}
 
-	pubB, err := pub.Bytes()
+	pubB, err := MarshalPublicKey(pub)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"strings"
 
-	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-cid"
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	b58 "github.com/mr-tron/base58/base58"
 	mh "github.com/multiformats/go-multihash"
@@ -220,7 +220,7 @@ func ToCid(id ID) cid.Cid {
 
 // IDFromPublicKey returns the Peer ID corresponding to the public key pk.
 func IDFromPublicKey(pk ic.PubKey) (ID, error) {
-	b, err := pk.Bytes()
+	b, err := ic.MarshalPublicKey(pk)
 	if err != nil {
 		return "", err
 	}

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -52,7 +52,7 @@ func (ks *keyset) generate() error {
 		return err
 	}
 
-	bpk, err := ks.pk.Bytes()
+	bpk, err := ic.MarshalPublicKey(ks.pk)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func (ks *keyset) load(hpkp, skBytesStr string) error {
 	}
 
 	ks.pk = ks.sk.GetPublic()
-	bpk, err := ks.pk.Bytes()
+	bpk, err := ic.MarshalPublicKey(ks.pk)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This method has been deprecated since May 2019.