### PR TITLE
move the event.Bus to eventbus.Bus, add a Start method to the Peerstore

### DIFF
--- a/event/bus_deprecated.go
+++ b/event/bus_deprecated.go
@@ -1,0 +1,34 @@
+package event
+
+import (
+	"github.com/libp2p/go-libp2p-core/eventbus"
+)
+
+// SubscriptionOpt represents a subscriber option. Use the options exposed by the implementation of choice.
+// Deprecated: Use eventbus.SubscriptionOpt
+type SubscriptionOpt = eventbus.SubscriptionOpt
+
+// EmitterOpt represents an emitter option. Use the options exposed by the implementation of choice.
+// Deprecated: Use eventbus.EmitterOpt
+type EmitterOpt = eventbus.EmitterOpt
+
+// CancelFunc closes a subscriber.
+// Deprecated: Use eventbus.CancelFunc
+type CancelFunc = eventbus.CancelFunc
+
+// WildcardSubscription is the type to subscribe to to receive all events
+// emitted in the eventbus.
+// Deprecated: Use eventbus.WildcardSubscription
+var WildcardSubscription = eventbus.WildcardSubscription
+
+// Emitter represents an actor that emits events onto the eventbus.
+// Deprecated: Use eventbus.Emitter
+type Emitter = eventbus.Emitter
+
+// Subscription represents a subscription to one or multiple event types.
+// Deprecated: Use eventbus.Subscription
+type Subscription = eventbus.Subscription
+
+// Bus is an interface for a type-based event delivery system.
+// Deprecated: Use eventbus.Bus
+type Bus = eventbus.Bus

--- a/eventbus/bus.go
+++ b/eventbus/bus.go
@@ -1,4 +1,4 @@
-package event
+package eventbus
 
 import (
 	"io"

--- a/host/host.go
+++ b/host/host.go
@@ -7,7 +7,7 @@ import (
 	"context"
 
 	"github.com/libp2p/go-libp2p-core/connmgr"
-	"github.com/libp2p/go-libp2p-core/event"
+	"github.com/libp2p/go-libp2p-core/eventbus"
 	"github.com/libp2p/go-libp2p-core/introspection"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -72,7 +72,7 @@ type Host interface {
 	ConnManager() connmgr.ConnManager
 
 	// EventBus returns the hosts eventbus
-	EventBus() event.Bus
+	EventBus() eventbus.Bus
 }
 
 // IntrospectableHost is implemented by Host implementations that are

--- a/peerstore/peerstore.go
+++ b/peerstore/peerstore.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	ic "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/eventbus"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/record"
 
@@ -60,6 +61,9 @@ type Peerstore interface {
 	PeerMetadata
 	Metrics
 	ProtoBook
+
+	// Start starts the garbage collection procedure.
+	Start(eventbus.Bus)
 
 	// PeerInfo returns a peer.PeerInfo struct for given peer.ID.
 	// This is a small slice of the information Peerstore has on


### PR DESCRIPTION
I'm a bit sad about this change (`event.Bus` just read so nice), but it's causing an import loop if we want to add a `Start(event.Bus)` method to the `Peerstore`.

We need this method to run the garbage collection Go routine in the peerstore (which removes disconnected peers from the peerstore after a grace period), see https://github.com/libp2p/go-libp2p-peerstore/pull/180.

The alternative to this approach would be to pass the `event.Bus` to the constructor of the `Peerstore` implementation. Arguably, this would be the nicer design. That way, we wouldn't need the interface to import the `event` package, avoiding the import cycle.
However, this conflicts with the assumption that the peerstore is a "standalone component" that can be constructed without any other components of the host. For example, this assumption is used go-libp2p to define the `DefaultPeerstore` option: https://github.com/libp2p/go-libp2p/blob/3a71a6d0591482de51b6eaa94093804ea21ab774/defaults.go#L49-L55.

Closes #221.