### PR TITLE
return a ConnectionStat instead of a Stat for the Conn

### DIFF
--- a/network/conn.go
+++ b/network/conn.go
@@ -63,5 +63,5 @@ type ConnMultiaddrs interface {
 // ConnStat is an interface mixin for connection types that provide connection statistics.
 type ConnStat interface {
 	// Stat stores metadata pertaining to this conn.
-	Stat() Stat
+	Stat() ConnectionStat
 }

--- a/network/network.go
+++ b/network/network.go
@@ -96,7 +96,14 @@ func (r Reachability) String() string {
 	return str[r]
 }
 
-// Stat stores metadata pertaining to a given Stream/Conn.
+// ConnectionStat stores metadata pertaining to a given Conn.
+type ConnectionStat struct {
+	Stat
+	// NumStreams is the number of streams on the connection.
+	NumStreams int
+}
+
+// Stat stores metadata pertaining to a given Stream / Conn.
 type Stat struct {
 	// Direction specifies whether this is an inbound or an outbound connection.
 	Direction Direction


### PR DESCRIPTION
This allows us to expose the number of streams that are currently open on a connection, which will allow us to prioritize killing of connections with many streams in the connection manager.