### PR TITLE
remove duplicate io.Closer on Network interface

### DIFF
--- a/network/network.go
+++ b/network/network.go
@@ -145,8 +145,6 @@ type Network interface {
 	// listens. It expands "any interface" addresses (/ip4/0.0.0.0, /ip6/::) to
 	// use the known local interfaces.
 	InterfaceListenAddresses() ([]ma.Multiaddr, error)
-
-	io.Closer
 }
 
 // Dialer represents a service that can dial out to peers


### PR DESCRIPTION
Is there a special purpose to define two `io.Closer` in the `Network` interface?