### PR TITLE
remove the DialTimeout

### DIFF
--- a/transport/transport.go
+++ b/transport/transport.go
@@ -14,11 +14,6 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 )
 
-// DialTimeout is the maximum duration a Dial is allowed to take.
-// This includes the time between dialing the raw network connection,
-// protocol selection as well the handshake, if applicable.
-var DialTimeout = 15 * time.Second
-
 // AcceptTimeout is the maximum duration an Accept is allowed to take.
 // This includes the time between accepting the raw network connection,
 // protocol selection as well as the handshake, if applicable.


### PR DESCRIPTION
The timeout should be a configuration option for the swarm, not a global variable.

Related change in the swarm: https://github.com/libp2p/go-libp2p-swarm/pull/302.

We should probably do the same for the `AcceptTimeout`.