### PR TITLE
crypto: accept ed25519 priv key as a value type

### DIFF
--- a/crypto/key_openssl.go
+++ b/crypto/key_openssl.go
@@ -32,6 +32,11 @@ func KeyPairFromStdKey(priv crypto.PrivateKey) (PrivKey, PubKey, error) {
 	case *ecdsa.PrivateKey:
 		return &ECDSAPrivateKey{p}, &ECDSAPublicKey{&p.PublicKey}, nil
 
+	case ed25519.PrivateKey:
+		pubIfc := p.Public()
+		pub, _ := pubIfc.(ed25519.PublicKey)
+		return &Ed25519PrivateKey{p}, &Ed25519PublicKey{pub}, nil
+
 	case *ed25519.PrivateKey:
 		pubIfc := p.Public()
 		pub, _ := pubIfc.(ed25519.PublicKey)
@@ -47,8 +52,26 @@ func KeyPairFromStdKey(priv crypto.PrivateKey) (PrivKey, PubKey, error) {
 	}
 }
 
-// PrivKeyToStdKey converts libp2p/go-libp2p-core/crypto private keys to standard library (and secp256k1) private keys
+// Deprecated: use PrivKeyToStdCompatKey instead.
 func PrivKeyToStdKey(priv PrivKey) (crypto.PrivateKey, error) {
+	stdKey, err := PrivKeyToStdCompatKey(priv)
+	if err != nil {
+		return nil, err
+	}
+	// for backward compatibility
+	if val, isEd := stdKey.(ed25519.PrivateKey); isEd {
+		return &val, nil
+	}
+	return stdKey
+}
+
+// PrivKeyToStdCompatKey converts libp2p/go-libp2p-core/crypto private keys to types
+// compatible with standard library (and secp256k1) private keys.
+//
+// In contrast to deprecated PrivKeyToStdKey, it returns ed25519.PrivateKey
+// instead od pointer to it. This is beacuse it's underlying type is []byte
+// and this value is used in std crypto packages.
+func PrivKeyToStdCompatKey(priv PrivKey) (crypto.PrivateKey, error) {
 	if priv == nil {
 		return nil, ErrNilPrivateKey
 	}
@@ -62,7 +85,7 @@ func PrivKeyToStdKey(priv PrivKey) (crypto.PrivateKey, error) {
 	case *ECDSAPrivateKey:
 		return p.priv, nil
 	case *Ed25519PrivateKey:
-		return &p.k, nil
+		return p.k, nil
 	case *Secp256k1PrivateKey:
 		return p, nil
 	default:


### PR DESCRIPTION
Since underlying type is []byte, the ed25519 key is generally passed as a value, not a pointer.

In particular, nowhere in std crypto package it is, nor any common parsing functions returns it this way.
The test itself shows the issue: whereas all other keys are passed as they are got from their respective generators,
ed25519 needs additional pointer retrieval.  Also the behaviour is inconsistent, since in function PubKeyToStdKey in the case for Ed25519 a value to type with underlying []byte is returned, not a pointer.

This is a breaking change though, so if the lib is considered stable, the previous method should be deprecated and new one created.