### PR TITLE
chore: add `String()` method to `IDSlice` type

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -209,3 +209,11 @@ type IDSlice []ID
 func (es IDSlice) Len() int           { return len(es) }
 func (es IDSlice) Swap(i, j int)      { es[i], es[j] = es[j], es[i] }
 func (es IDSlice) Less(i, j int) bool { return string(es[i]) < string(es[j]) }
+
+func (es IDSlice) String() string {
+	peersStrings := make([]string, len(es))
+	for i, id := range es {
+		peersStrings[i] = id.String()
+	}
+	return strings.Join(peersStrings, ", ")
+}


### PR DESCRIPTION
### Description

- Initialize and preallocate the slice of strings
- use the method `String` for each `ID` and put in the slice 
- return a string of ids separated by `, `

Tiny demonstration: https://go.dev/play/p/kd_nd-edWnr

Original suggestion -> https://github.com/ChainSafe/gossamer/pull/2267#discussion_r826306828