### PR TITLE
fix: switch to go-multicodec mappings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/minio/sha256-simd v0.1.1
 	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.4.1
+	github.com/multiformats/go-multicodec v0.4.1
 	github.com/multiformats/go-multihash v0.0.14
 	github.com/multiformats/go-varint v0.0.6
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,8 @@ github.com/multiformats/go-multiaddr v0.4.1 h1:Pq37uLx3hsyNlTDir7FZyU8+cFCTqd5y1
 github.com/multiformats/go-multiaddr v0.4.1/go.mod h1:3afI9HfVW8csiF8UZqtpYRiDyew8pRX7qLIGHu9FLuM=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
+github.com/multiformats/go-multicodec v0.4.1 h1:BSJbf+zpghcZMZrwTYBGwy0CPcVZGWiC72Cp8bBd4R4=
+github.com/multiformats/go-multicodec v0.4.1/go.mod h1:1Hj/eHRaVWSXiSNNfcEPcwZleTmdNP81xlxDLnWU9GQ=
 github.com/multiformats/go-multihash v0.0.13/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=
 github.com/multiformats/go-multihash v0.0.14 h1:QoBceQYQQtNUuf6s7wHxnE2c8bhbMqhfGzNI032se/I=
 github.com/multiformats/go-multihash v0.0.14/go.mod h1:VdAWLKTwram9oKAatUcLxBNUjdtcVwxObEQBtRfuyjc=

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-cid"
 	ic "github.com/libp2p/go-libp2p-core/crypto"
 	b58 "github.com/mr-tron/base58/base58"
+	mc "github.com/multiformats/go-multicodec"
 	mh "github.com/multiformats/go-multihash"
 )
 
@@ -162,13 +163,9 @@ func Encode(id ID) string {
 
 // FromCid converts a CID to a peer ID, if possible.
 func FromCid(c cid.Cid) (ID, error) {
-	ty := c.Type()
-	if ty != cid.Libp2pKey {
-		s := cid.CodecToStr[ty]
-		if s == "" {
-			s = fmt.Sprintf("[unknown multicodec %d]", ty)
-		}
-		return "", fmt.Errorf("can't convert CID of type %s to a peer ID", s)
+	code := mc.Code(c.Type())
+	if code != mc.Libp2pKey {
+		return "", fmt.Errorf("can't convert CID of type %s to a peer ID", code.String())
 	}
 	return ID(c.Hash()), nil
 }


### PR DESCRIPTION
The mappings in go-cid were maintained by hand and are invalid.
More details in https://github.com/ipfs/go-cid/pull/137

This PR is switching to go-multicodec which has correct mappings that are generated from https://github.com/multiformats/multicodec/blob/master/table.csv, removing the surface for human error.