### PR TITLE
feat: harden encoding/decoding functions against panics

### DIFF
--- a/crypto/ecdsa.go
+++ b/crypto/ecdsa.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
+	"github.com/libp2p/go-libp2p-core/internal/catch"
 
 	"github.com/minio/sha256-simd"
 )
@@ -73,17 +74,21 @@ func ECDSAPublicKeyFromPubKey(pub ecdsa.PublicKey) (PubKey, error) {
 }
 
 // MarshalECDSAPrivateKey returns x509 bytes from a private key
-func MarshalECDSAPrivateKey(ePriv ECDSAPrivateKey) ([]byte, error) {
+func MarshalECDSAPrivateKey(ePriv ECDSAPrivateKey) (res []byte, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "ECDSA private-key marshal") }()
 	return x509.MarshalECPrivateKey(ePriv.priv)
 }
 
 // MarshalECDSAPublicKey returns x509 bytes from a public key
-func MarshalECDSAPublicKey(ePub ECDSAPublicKey) ([]byte, error) {
+func MarshalECDSAPublicKey(ePub ECDSAPublicKey) (res []byte, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "ECDSA public-key marshal") }()
 	return x509.MarshalPKIXPublicKey(ePub.pub)
 }
 
 // UnmarshalECDSAPrivateKey returns a private key from x509 bytes
-func UnmarshalECDSAPrivateKey(data []byte) (PrivKey, error) {
+func UnmarshalECDSAPrivateKey(data []byte) (res PrivKey, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "ECDSA private-key unmarshal") }()
+
 	priv, err := x509.ParseECPrivateKey(data)
 	if err != nil {
 		return nil, err
@@ -93,7 +98,9 @@ func UnmarshalECDSAPrivateKey(data []byte) (PrivKey, error) {
 }
 
 // UnmarshalECDSAPublicKey returns the public key from x509 bytes
-func UnmarshalECDSAPublicKey(data []byte) (PubKey, error) {
+func UnmarshalECDSAPublicKey(data []byte) (key PubKey, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "ECDSA public-key unmarshal") }()
+
 	pubIfc, err := x509.ParsePKIXPublicKey(data)
 	if err != nil {
 		return nil, err
@@ -113,7 +120,8 @@ func (ePriv *ECDSAPrivateKey) Type() pb.KeyType {
 }
 
 // Raw returns x509 bytes from a private key
-func (ePriv *ECDSAPrivateKey) Raw() ([]byte, error) {
+func (ePriv *ECDSAPrivateKey) Raw() (res []byte, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "ECDSA private-key marshal") }()
 	return x509.MarshalECPrivateKey(ePriv.priv)
 }
 
@@ -123,7 +131,8 @@ func (ePriv *ECDSAPrivateKey) Equals(o Key) bool {
 }
 
 // Sign returns the signature of the input data
-func (ePriv *ECDSAPrivateKey) Sign(data []byte) ([]byte, error) {
+func (ePriv *ECDSAPrivateKey) Sign(data []byte) (sig []byte, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "ECDSA signing") }()
 	hash := sha256.Sum256(data)
 	r, s, err := ecdsa.Sign(rand.Reader, ePriv.priv, hash[:])
 	if err != nil {
@@ -157,7 +166,16 @@ func (ePub *ECDSAPublicKey) Equals(o Key) bool {
 }
 
 // Verify compares data to a signature
-func (ePub *ECDSAPublicKey) Verify(data, sigBytes []byte) (bool, error) {
+func (ePub *ECDSAPublicKey) Verify(data, sigBytes []byte) (success bool, err error) {
+	defer func() {
+		catch.HandlePanic(recover(), &err, "ECDSA signature verification")
+
+		// Just to be extra paranoid.
+		if err != nil {
+			success = false
+		}
+	}()
+
 	sig := new(ECDSASig)
 	if _, err := asn1.Unmarshal(sigBytes, sig); err != nil {
 		return false, err

--- a/internal/catch/catch.go
+++ b/internal/catch/catch.go
@@ -1,0 +1,18 @@
+package catch
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime/debug"
+)
+
+var panicWriter io.Writer = os.Stderr
+
+// HandlePanic handles and logs panics.
+func HandlePanic(rerr interface{}, err *error, where string) {
+	if rerr != nil {
+		fmt.Fprintf(panicWriter, "caught panic: %s\n%s\n", rerr, debug.Stack())
+		*err = fmt.Errorf("panic in %s: %s", where, rerr)
+	}
+}

--- a/internal/catch/catch_test.go
+++ b/internal/catch/catch_test.go
@@ -1,0 +1,28 @@
+package catch
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCatch(t *testing.T) {
+	buf := new(bytes.Buffer)
+
+	oldPanicWriter := panicWriter
+	t.Cleanup(func() { panicWriter = oldPanicWriter })
+	panicWriter = buf
+
+	panicAndCatch := func() (err error) {
+		defer func() { HandlePanic(recover(), &err, "somewhere") }()
+
+		panic("here")
+	}
+
+	err := panicAndCatch()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "panic in somewhere: here")
+
+	require.Contains(t, buf.String(), "caught panic: here")
+}

--- a/peer/addrinfo_serde.go
+++ b/peer/addrinfo_serde.go
@@ -3,6 +3,7 @@ package peer
 import (
 	"encoding/json"
 
+	"github.com/libp2p/go-libp2p-core/internal/catch"
 	ma "github.com/multiformats/go-multiaddr"
 )
 
@@ -12,7 +13,9 @@ type addrInfoJson struct {
 	Addrs []string
 }
 
-func (pi AddrInfo) MarshalJSON() ([]byte, error) {
+func (pi AddrInfo) MarshalJSON() (res []byte, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "libp2p addr info marshal") }()
+
 	addrs := make([]string, len(pi.Addrs))
 	for i, addr := range pi.Addrs {
 		addrs[i] = addr.String()
@@ -23,7 +26,8 @@ func (pi AddrInfo) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (pi *AddrInfo) UnmarshalJSON(b []byte) error {
+func (pi *AddrInfo) UnmarshalJSON(b []byte) (err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "libp2p addr info unmarshal") }()
 	var data addrInfoJson
 	if err := json.Unmarshal(b, &data); err != nil {
 		return err

--- a/record/envelope.go
+++ b/record/envelope.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/internal/catch"
 	pb "github.com/libp2p/go-libp2p-core/record/pb"
 
 	pool "github.com/libp2p/go-buffer-pool"
@@ -192,7 +193,8 @@ func UnmarshalEnvelope(data []byte) (*Envelope, error) {
 
 // Marshal returns a byte slice containing a serialized protobuf representation
 // of a Envelope.
-func (e *Envelope) Marshal() ([]byte, error) {
+func (e *Envelope) Marshal() (res []byte, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "libp2p envelope marshal") }()
 	key, err := crypto.PublicKeyToProto(e.PublicKey)
 	if err != nil {
 		return nil, err

--- a/record/record.go
+++ b/record/record.go
@@ -3,6 +3,8 @@ package record
 import (
 	"errors"
 	"reflect"
+
+	"github.com/libp2p/go-libp2p-core/internal/catch"
 )
 
 var (
@@ -70,7 +72,9 @@ func RegisterType(prototype Record) {
 	payloadTypeRegistry[string(prototype.Codec())] = getValueType(prototype)
 }
 
-func unmarshalRecordPayload(payloadType []byte, payloadBytes []byte) (Record, error) {
+func unmarshalRecordPayload(payloadType []byte, payloadBytes []byte) (_rec Record, err error) {
+	defer func() { catch.HandlePanic(recover(), &err, "libp2p envelope record unmarshal") }()
+
 	rec, err := blankRecordForPayloadType(payloadType)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Part of https://github.com/libp2p/go-libp2p/issues/1389

These kinds of functions:

1. Handle user input.
2. Often have out-of-bounds, null pointer, etc bugs.
3. Have completely isolated logic where local panics are unlikely to cause memory corruption elsewhere.