### PR TITLE
deprecate Negotiator.NegotiateLazy

### DIFF
--- a/protocol/switch.go
+++ b/protocol/switch.go
@@ -51,7 +51,6 @@ type Router interface {
 // Negotiator is a component capable of reaching agreement over what protocols
 // to use for inbound streams of communication.
 type Negotiator interface {
-
 	// NegotiateLazy will return the registered protocol handler to use
 	// for a given inbound stream, returning as soon as the protocol has been
 	// determined. Returns an error if negotiation fails.
@@ -59,6 +58,8 @@ type Negotiator interface {
 	// NegotiateLazy may return before all protocol negotiation responses have been
 	// written to the stream. This is in contrast to Negotiate, which will block until
 	// the Negotiator is finished with the stream.
+	//
+	// Deprecated: use Negotiate instead.
 	NegotiateLazy(rwc io.ReadWriteCloser) (io.ReadWriteCloser, string, HandlerFunc, error)
 
 	// Negotiate will return the registered protocol handler to use for a given


### PR DESCRIPTION
As discussed in https://github.com/multiformats/go-multistream/pull/85, `NegotiateLazy` was pretty uninteresting: all that it did was do the writes asynchronously.

Thanks to @MarcoPolo for pointing out that we also need to deprecate the function on the interface in https://github.com/libp2p/go-libp2p/pull/1417#issuecomment-1106432555.