### PR TITLE
remove OpenedStream and ClosedStream from Notifiee interface

### DIFF
--- a/network/notifee.go
+++ b/network/notifee.go
@@ -13,10 +13,6 @@ type Notifiee interface {
 	Disconnected(Network, Conn)        // called when a connection closed
 	OpenedStream(Network, Stream)      // called when a stream opened
 	ClosedStream(Network, Stream)      // called when a stream closed
-
-	// TODO
-	// PeerConnected(Network, peer.ID)    // called when a peer connected
-	// PeerDisconnected(Network, peer.ID) // called when a peer disconnected
 }
 
 // NotifyBundle implements Notifiee by calling any of the functions set on it,

--- a/network/notifee.go
+++ b/network/notifee.go
@@ -11,8 +11,6 @@ type Notifiee interface {
 	ListenClose(Network, ma.Multiaddr) // called when network stops listening on an addr
 	Connected(Network, Conn)           // called when a connection opened
 	Disconnected(Network, Conn)        // called when a connection closed
-	OpenedStream(Network, Stream)      // called when a stream opened
-	ClosedStream(Network, Stream)      // called when a stream closed
 }
 
 // NotifyBundle implements Notifiee by calling any of the functions set on it,
@@ -24,9 +22,6 @@ type NotifyBundle struct {
 
 	ConnectedF    func(Network, Conn)
 	DisconnectedF func(Network, Conn)
-
-	OpenedStreamF func(Network, Stream)
-	ClosedStreamF func(Network, Stream)
 }
 
 var _ Notifiee = (*NotifyBundle)(nil)
@@ -59,20 +54,6 @@ func (nb *NotifyBundle) Disconnected(n Network, c Conn) {
 	}
 }
 
-// OpenedStream calls OpenedStreamF if it is not null.
-func (nb *NotifyBundle) OpenedStream(n Network, s Stream) {
-	if nb.OpenedStreamF != nil {
-		nb.OpenedStreamF(n, s)
-	}
-}
-
-// ClosedStream calls ClosedStreamF if it is not null.
-func (nb *NotifyBundle) ClosedStream(n Network, s Stream) {
-	if nb.ClosedStreamF != nil {
-		nb.ClosedStreamF(n, s)
-	}
-}
-
 // Global noop notifiee. Do not change.
 var GlobalNoopNotifiee = &NoopNotifiee{}
 
@@ -84,5 +65,3 @@ func (nn *NoopNotifiee) Connected(n Network, c Conn)              {}
 func (nn *NoopNotifiee) Disconnected(n Network, c Conn)           {}
 func (nn *NoopNotifiee) Listen(n Network, addr ma.Multiaddr)      {}
 func (nn *NoopNotifiee) ListenClose(n Network, addr ma.Multiaddr) {}
-func (nn *NoopNotifiee) OpenedStream(Network, Stream)             {}
-func (nn *NoopNotifiee) ClosedStream(Network, Stream)             {}

--- a/network/notifee_test.go
+++ b/network/notifee_test.go
@@ -85,39 +85,3 @@ func TestDisconnected(T *testing.T) {
 		T.Fatal("Disconnected should have been called")
 	}
 }
-
-func TestOpenedStream(T *testing.T) {
-	var notifee NotifyBundle
-	notifee.OpenedStream(nil, nil)
-
-	called := false
-	notifee.OpenedStreamF = func(Network, Stream) {
-		called = true
-	}
-	if called {
-		T.Fatal("called should be false")
-	}
-
-	notifee.OpenedStream(nil, nil)
-	if !called {
-		T.Fatal("OpenedStream should have been called")
-	}
-}
-
-func TestClosedStream(T *testing.T) {
-	var notifee NotifyBundle
-	notifee.ClosedStream(nil, nil)
-
-	called := false
-	notifee.ClosedStreamF = func(Network, Stream) {
-		called = true
-	}
-	if called {
-		T.Fatal("called should be false")
-	}
-
-	notifee.ClosedStream(nil, nil)
-	if !called {
-		T.Fatal("ClosedStream should have been called")
-	}
-}


### PR DESCRIPTION
As far as I can tell, nobody is using the `OpenedStream` and `ClosedStream` notification.

This is because they're not really useful: You can get a notification that the swarm opened a new stream, but you can read, write, close or reset the stream without interfering with the application. Therefore you won't even know which libp2p protocol is being negotiated on that stream.