### PR TITLE
Only log once if we failed to convert from netAddr

### DIFF
--- a/canonicallog/canonicallog.go
+++ b/canonicallog/canonicallog.go
@@ -24,7 +24,8 @@ func LogMisbehavingPeer(p peer.ID, peerAddr multiaddr.Multiaddr, component strin
 func LogMisbehavingPeerNetAddr(p peer.ID, peerAddr net.Addr, component string, originalErr error, msg string) {
 	ma, err := manet.FromNetAddr(peerAddr)
 	if err != nil {
-		log.Errorf("CANONICAL_MISBEHAVING_PEER: peer=%s netAddr=%s component=%s err=%v msg=%s", p, peerAddr.String(), component, originalErr, msg)
+		log.Errorf("CANONICAL_MISBEHAVING_PEER: peer=%s netAddr=%s component=%s err=%v fromNetAddrErr=%v msg=%s", p, peerAddr.String(), component, originalErr, err, msg)
+		return
 	}
 
 	log.Errorf("CANONICAL_MISBEHAVING_PEER: peer=%s addr=%s component=%s err=%v msg=%s", p, ma, component, originalErr, msg)

--- a/canonicallog/canonicallog_test.go
+++ b/canonicallog/canonicallog_test.go
@@ -2,6 +2,7 @@ package canonicallog
 
 import (
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/libp2p/go-libp2p-core/test"
@@ -10,10 +11,7 @@ import (
 
 func TestLogs(t *testing.T) {
 	LogMisbehavingPeer(test.RandPeerIDFatal(t), multiaddr.StringCast("/ip4/1.2.3.4"), "somecomponent", fmt.Errorf("something"), "hi")
-	LogMisbehavingPeerNetAddr(test.RandPeerIDFatal(t), dummyNetAddr{}, "somecomponent", fmt.Errorf("something"), "hi")
+
+	netAddr := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 80}
+	LogMisbehavingPeerNetAddr(test.RandPeerIDFatal(t), netAddr, "somecomponent", fmt.Errorf("something"), "hi")
 }
-
-type dummyNetAddr struct{}
-
-func (d dummyNetAddr) Network() string { return "tcp" }
-func (d dummyNetAddr) String() string  { return "127.0.0.1:80" }


### PR DESCRIPTION
I realized I didn't return after the error check when converting a net.Addr. So it ended up logging twice in that case.

Fixed to log only once as well as the conversion error so it's apparent what went wrong.
