### PR TITLE
deprecate peer.ID.Pretty

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -42,19 +42,20 @@ const maxInlineKeyLength = 42
 type ID string
 
 // Pretty returns a base58-encoded string representation of the ID.
+// Deprecated: use String() instead.
 func (id ID) Pretty() string {
-	return Encode(id)
+	return id.String()
 }
 
 // Loggable returns a pretty peer ID string in loggable JSON format.
 func (id ID) Loggable() map[string]interface{} {
 	return map[string]interface{}{
-		"peerID": id.Pretty(),
+		"peerID": id.String(),
 	}
 }
 
 func (id ID) String() string {
-	return id.Pretty()
+	return Encode(id)
 }
 
 // ShortString prints out the peer ID.
@@ -64,7 +65,7 @@ func (id ID) String() string {
 // IDs safely. Then any peer.ID type found in the
 // codebase is known to be correct.
 func (id ID) ShortString() string {
-	pid := id.Pretty()
+	pid := id.String()
 	if len(pid) <= 10 {
 		return fmt.Sprintf("<peer.ID %s>", pid)
 	}

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -88,7 +88,6 @@ func (ks *keyset) load(hpkp, skBytesStr string) error {
 }
 
 func TestIDMatchesPublicKey(t *testing.T) {
-
 	test := func(ks keyset) {
 		p1, err := Decode(ks.hpkp)
 		if err != nil {
@@ -109,11 +108,11 @@ func TestIDMatchesPublicKey(t *testing.T) {
 		}
 
 		if p1 != p2 {
-			t.Error("p1 and p2 differ", p1.Pretty(), p2.Pretty())
+			t.Error("p1 and p2 differ", p1.String(), p2.String())
 		}
 
-		if p2.Pretty() != ks.hpkp {
-			t.Error("hpkp and p2.Pretty differ", ks.hpkp, p2.Pretty())
+		if p2.String() != ks.hpkp {
+			t.Error("hpkp and p2.String differ", ks.hpkp, p2.String())
 		}
 	}
 
@@ -144,7 +143,7 @@ func TestIDMatchesPrivateKey(t *testing.T) {
 		}
 
 		if p1 != p2 {
-			t.Error("p1 and p2 differ", p1.Pretty(), p2.Pretty())
+			t.Error("p1 and p2 differ", p1.String(), p2.String())
 		}
 	}
 


### PR DESCRIPTION
1. It's an alias for peer.ID.String
2. fmt.Stringer is the idiomatic way to get a string representation in Go.