### PR TITLE
remove peer.IDFromString

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -113,15 +113,6 @@ func (id ID) Validate() error {
 	return nil
 }
 
-// IDFromString casts a string to the ID type, and validates
-// the value to make sure it is a multihash.
-func IDFromString(s string) (ID, error) {
-	if _, err := mh.Cast([]byte(s)); err != nil {
-		return ID(""), err
-	}
-	return ID(s), nil
-}
-
 // IDFromBytes casts a byte slice to the ID type, and validates
 // the value to make sure it is a multihash.
 func IDFromBytes(b []byte) (ID, error) {


### PR DESCRIPTION
This method is almost always used incorrectly. Contrary to what the name indicates, the following *does not* work:
```go
var id peer.ID
id2 := peer.IDFromString()
// id is not == id2 now!
```

The reason is that `String()` encodes the peer ID, so you need to call `Decode` instead. The existence of this function has cost me hours and hours of debugging, and we continue to use it in places where we shouldn't. We'd be better off if this function didn't exist.

Here's where we got this wrong in go-libp2p: https://github.com/libp2p/go-libp2p/pull/1644
And I'm pretty sure that lotus also got it wrong here: https://github.com/filecoin-project/lotus/blob/1de56d5e470d743e8b1542c889411360c84db431/node/modules/lp2p/libp2p.go#L70-L78 (I haven't followed the entire code path where these peer IDs originate from, but assuming they come from a config file, they're most likely encoded peer IDs)