### PR TITLE
deprecate peer.Encode in favor of peer.ID.String

### DIFF
--- a/peer/peer.go
+++ b/peer/peer.go
@@ -55,7 +55,7 @@ func (id ID) Loggable() map[string]interface{} {
 }
 
 func (id ID) String() string {
-	return Encode(id)
+	return b58.Encode([]byte(id))
 }
 
 // ShortString prints out the peer ID.
@@ -158,8 +158,10 @@ func Decode(s string) (ID, error) {
 //
 // At the moment, it base58 encodes the peer ID but, in the future, it will
 // switch to encoding it as a CID by default.
+//
+// Deprecated: use id.String instead.
 func Encode(id ID) string {
-	return b58.Encode([]byte(id))
+	return id.String()
 }
 
 // FromCid converts a CID to a peer ID, if possible.

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -176,7 +176,7 @@ func TestIDEncoding(t *testing.T) {
 			t.Fatal("failed to round trip through CID string")
 		}
 
-		if ks.hpkp != Encode(p1) {
+		if ks.hpkp != p1.String() {
 			t.Fatal("should always encode peer IDs as base58 by default")
 		}
 	}

--- a/routing/query_serde.go
+++ b/routing/query_serde.go
@@ -8,7 +8,7 @@ import (
 
 func (qe *QueryEvent) MarshalJSON() ([]byte, error) {
 	return json.Marshal(map[string]interface{}{
-		"ID":        peer.Encode(qe.ID),
+		"ID":        qe.ID.String(),
 		"Type":      int(qe.Type),
 		"Responses": qe.Responses,
 		"Extra":     qe.Extra,


### PR DESCRIPTION
Trying to reduce the function sprawl in this package a bit.